### PR TITLE
Replace inline links with link buttons

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -50,7 +50,10 @@
     .badge-issues { background: #4a1942; color: #ce93d8; }
     .badge-prs { background: #0d3b66; color: #81d4fa; }
     .badge-zero { opacity: 0.4; }
+    .repo-name { cursor: pointer; }
     .repo-date { color: #666; font-size: 12px; white-space: nowrap; }
+    .link-btn { display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 28px; border-radius: 4px; background: #252542; color: #2196f3; text-decoration: none; font-size: 14px; }
+    .link-btn:hover { background: #2a2a50; color: #64b5f6; }
     .detail-panel { background: #0f1525; border-bottom: 1px solid #333; }
     .detail-panel td { padding: 16px 12px; }
     .detail-section { margin-bottom: 16px; }
@@ -91,6 +94,7 @@
       .repo-table th:nth-child(3), .repo-table td:nth-child(3),
       .repo-table th:nth-child(4), .repo-table td:nth-child(4),
       .repo-table th:nth-child(6), .repo-table td:nth-child(6) { display: none; }
+      .link-btn { width: 24px; height: 24px; font-size: 12px; }
       .repo-row td { padding: 8px 6px; }
       .repo-table th { padding: 6px; }
       .detail-panel td { padding: 10px 6px; }

--- a/src/View.purs
+++ b/src/View.purs
@@ -275,6 +275,7 @@ renderRepoTable state repos =
             , HH.th_ [ HH.text "Vis" ]
             , HH.th_ [ HH.text "Issues" ]
             , HH.th_ [ HH.text "Updated" ]
+            , HH.th_ []
             ]
         ]
     , HH.tbody_
@@ -299,10 +300,8 @@ renderRepoRow state (Repo r) =
         , HP.class_ (HH.ClassName rowClass)
         ]
         [ HH.td_
-            [ HH.a
-                [ HP.href r.htmlUrl
-                , HP.target "_blank"
-                , HP.class_
+            [ HH.span
+                [ HP.class_
                     (HH.ClassName "repo-name")
                 ]
                 [ HH.text r.name ]
@@ -330,6 +329,8 @@ renderRepoRow state (Repo r) =
                 ]
                 [ HH.text (formatDate r.updatedAt) ]
             ]
+        , HH.td_
+            [ linkButton r.htmlUrl ]
         ]
     ]
       <>
@@ -387,7 +388,7 @@ renderDetailPanel state =
   HH.tr
     [ HP.class_ (HH.ClassName "detail-panel") ]
     [ HH.td
-        [ HP.colSpan 6 ]
+        [ HP.colSpan 7 ]
         [ if state.detailLoading then
             HH.div
               [ HP.class_
@@ -461,10 +462,8 @@ renderIssueRow state (Issue i) =
         , HP.class_ (HH.ClassName "repo-row")
         ]
         [ HH.td_
-            [ HH.a
-                [ HP.href i.htmlUrl
-                , HP.target "_blank"
-                , HP.class_
+            [ HH.span
+                [ HP.class_
                     (HH.ClassName "detail-link")
                 ]
                 [ HH.text
@@ -491,6 +490,8 @@ renderIssueRow state (Issue i) =
                     (formatDate i.createdAt)
                 ]
             ]
+        , HH.td_
+            [ linkButton i.htmlUrl ]
         ]
     ]
       <>
@@ -545,10 +546,8 @@ renderPRRow state (PullRequest pr) =
         , HP.class_ (HH.ClassName "repo-row")
         ]
         [ HH.td_
-            ( [ HH.a
-                  [ HP.href pr.htmlUrl
-                  , HP.target "_blank"
-                  , HP.class_
+            ( [ HH.span
+                  [ HP.class_
                       (HH.ClassName "detail-link")
                   ]
                   [ HH.text
@@ -587,6 +586,8 @@ renderPRRow state (PullRequest pr) =
                     (formatDate pr.createdAt)
                 ]
             ]
+        , HH.td_
+            [ linkButton pr.htmlUrl ]
         ]
     ]
       <>
@@ -606,7 +607,7 @@ renderMarkdownRow = case _ of
     [ HH.tr
         [ HP.class_ (HH.ClassName "detail-row") ]
         [ HH.td
-            [ HP.colSpan 3 ]
+            [ HP.colSpan 4 ]
             [ HH.div
                 [ HP.class_
                     (HH.ClassName "detail-body")
@@ -620,6 +621,16 @@ renderMarkdownRow = case _ of
             ]
         ]
     ]
+
+-- | Small link button that opens a URL.
+linkButton :: forall w i. String -> HH.HTML w i
+linkButton url =
+  HH.a
+    [ HP.href url
+    , HP.target "_blank"
+    , HP.class_ (HH.ClassName "link-btn")
+    ]
+    [ HH.text "\x2197" ]
 
 -- | Render label tags.
 renderLabels


### PR DESCRIPTION
## Summary
- Remove inline `<a>` tags from repo/issue/PR row text
- Add a dedicated link button (↗) at the end of each row
- Rows are fully clickable for expand/collapse without accidentally navigating away
- Sized down on mobile