### PR TITLE
Add auto-refresh toggle button

### DIFF
--- a/src/Main.purs
+++ b/src/Main.purs
@@ -71,6 +71,7 @@ initialState =
   , filterText: ""
   , hasToken: false
   , expandedItems: Set.empty
+  , autoRefresh: true
   }
 
 render :: forall m. State -> H.ComponentHTML Action () m
@@ -129,7 +130,8 @@ handleAction = case _ of
     pure unit
   Tick -> do
     st <- H.get
-    if not st.hasToken then pure unit
+    if not st.hasToken || not st.autoRefresh then
+      pure unit
     else if st.secondsLeft <= 1 then do
       H.modify_ _
         { loading = true
@@ -198,6 +200,12 @@ handleAction = case _ of
         }
   SetFilter txt ->
     H.modify_ _ { filterText = txt }
+  ToggleAutoRefresh -> do
+    st <- H.get
+    H.modify_ _
+      { autoRefresh = not st.autoRefresh
+      , secondsLeft = st.interval
+      }
   ChangeInterval delta -> do
     st <- H.get
     let

--- a/src/View.purs
+++ b/src/View.purs
@@ -46,6 +46,7 @@ data Action
   | SetSort SortField
   | SetFilter String
   | ChangeInterval Int
+  | ToggleAutoRefresh
   | ResetAll
 
 -- | Application state (referenced by view).
@@ -65,6 +66,7 @@ type State =
   , filterText :: String
   , hasToken :: Boolean
   , expandedItems :: Set String
+  , autoRefresh :: Boolean
   }
 
 -- | Token input form shown when no token is set.
@@ -210,14 +212,30 @@ renderToolbar state =
     , HH.div
         [ HP.class_ (HH.ClassName "toolbar-timer") ]
         [ HH.button
+            [ HE.onClick \_ -> ToggleAutoRefresh
+            , HP.class_
+                ( HH.ClassName
+                    ( "btn-small"
+                        <> activeIf state.autoRefresh
+                    )
+                )
+            ]
+            [ HH.text
+                ( if state.autoRefresh then "Auto"
+                  else "Paused"
+                )
+            ]
+        , HH.button
             [ HE.onClick \_ -> ChangeInterval (-5)
             , HP.class_ (HH.ClassName "btn-small")
             ]
             [ HH.text "-" ]
         , HH.text
-            ( show state.secondsLeft <> "s / "
-                <> show state.interval
-                <> "s"
+            ( if state.autoRefresh then
+                show state.secondsLeft <> "s / "
+                  <> show state.interval
+                  <> "s"
+              else show state.interval <> "s"
             )
         , HH.button
             [ HE.onClick \_ -> ChangeInterval 5


### PR DESCRIPTION
## Summary
- Add Auto/Paused toggle button in toolbar to enable/disable auto-reload
- When paused, countdown stops and no automatic refreshes occur
- Toggling back on resets the countdown