### PR TITLE
Link to GitHub token creation in setup form

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -22,6 +22,8 @@
     .instructions ol, .instructions ul { padding-left: 20px; margin: 0; }
     .instructions li { margin-bottom: 4px; }
     .instructions code { color: #2196f3; background: #16213e; padding: 1px 5px; border-radius: 3px; font-size: 12px; }
+    .token-link { color: #2196f3; text-decoration: none; }
+    .token-link:hover { text-decoration: underline; }
     .toolbar { display: flex; gap: 8px; margin-bottom: 16px; align-items: center; flex-wrap: wrap; }
     .toolbar-timer { display: flex; align-items: center; gap: 6px; color: #666; font-size: 12px; margin-left: auto; font-variant-numeric: tabular-nums; }
     .btn-small { padding: 4px 10px; border: 1px solid #252542; border-radius: 4px; background: #252542; color: #9e9e9e; font-size: 12px; cursor: pointer; }

--- a/src/View.purs
+++ b/src/View.purs
@@ -109,12 +109,19 @@ renderTokenForm state =
         [ HH.h3_ [ HH.text "Getting started" ]
         , HH.ol_
             [ HH.li_
-                [ HH.text "Create a "
-                , HH.strong_
-                    [ HH.text "GitHub token" ]
-                , HH.text " with "
+                [ HH.a
+                    [ HP.href
+                        "https://github.com/settings/tokens/new?scopes=repo&description=gh-dashboard"
+                    , HP.target "_blank"
+                    , HP.class_
+                        (HH.ClassName "token-link")
+                    ]
+                    [ HH.text
+                        "Create a GitHub token"
+                    ]
+                , HH.text " (select "
                 , HH.code_ [ HH.text "repo" ]
-                , HH.text " scope"
+                , HH.text " scope)"
                 ]
             , HH.li_
                 [ HH.text


### PR DESCRIPTION
## Summary
- Replace plain text with direct link to GitHub token creation page
- Link pre-fills repo scope and description for convenience