### PR TITLE
Add live demo link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # gh-dashboard
 
+**[Live demo](https://paolino.github.io/gh-dashboard/)**
+
 Repository dashboard for GitHub — browse your repos, open issues and pull requests on a single page with auto-refresh, expandable detail panels and inline markdown rendering.
 
 **Runs entirely in your browser.** There is no server — the app is a static page hosted on GitHub Pages. Your GitHub token is stored in localStorage and sent only to the GitHub API. Nothing is logged or transmitted to any third party.


### PR DESCRIPTION
## Summary
- Add link to deployed GitHub Pages site at top of README