### PR TITLE
Collapsible issues and PRs sections

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -62,6 +62,8 @@
     .detail-section { margin-bottom: 16px; }
     .detail-section:last-child { margin-bottom: 0; }
     .detail-heading { color: #777; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
+    .detail-heading.clickable { cursor: pointer; }
+    .detail-heading.clickable:hover { color: #e0e0e0; }
     .detail-table { width: 100%; border-collapse: collapse; }
     .detail-table td { padding: 6px 8px; border-bottom: 1px solid #1a1a2e; font-size: 13px; }
     .detail-link { color: #2196f3; text-decoration: none; }

--- a/src/View.purs
+++ b/src/View.purs
@@ -455,29 +455,39 @@ renderIssuesSection
   -> Int
   -> HH.HTML w Action
 renderIssuesSection state issues count =
-  HH.div
-    [ HP.class_ (HH.ClassName "detail-section") ]
-    [ HH.div
-        [ HP.class_
-            (HH.ClassName "detail-heading")
-        ]
-        [ HH.text
-            ("Issues (" <> show count <> ")")
-        ]
-    , if null issues then
-        HH.div
-          [ HP.class_ (HH.ClassName "empty-msg") ]
-          [ HH.text "No open issues" ]
-      else
-        HH.table
+  let
+    key = "section-issues"
+    isOpen = Set.member key state.expandedItems
+  in
+    HH.div
+      [ HP.class_ (HH.ClassName "detail-section") ]
+      [ HH.div
           [ HP.class_
-              (HH.ClassName "detail-table")
+              (HH.ClassName "detail-heading clickable")
+          , HE.onClick \_ -> ToggleItem key
           ]
-          [ HH.tbody_
-              ( issues >>= renderIssueRow state
+          [ HH.text
+              ( (if isOpen then "\x25BE " else "\x25B8 ")
+                  <> "Issues ("
+                  <> show count
+                  <> ")"
               )
           ]
-    ]
+      , if not isOpen then HH.text ""
+        else if null issues then
+          HH.div
+            [ HP.class_ (HH.ClassName "empty-msg") ]
+            [ HH.text "No open issues" ]
+        else
+          HH.table
+            [ HP.class_
+                (HH.ClassName "detail-table")
+            ]
+            [ HH.tbody_
+                ( issues >>= renderIssueRow state
+                )
+            ]
+      ]
 
 -- | Single issue row + optional body row.
 renderIssueRow
@@ -540,28 +550,38 @@ renderPRsSection
   -> Int
   -> HH.HTML w Action
 renderPRsSection state prs count =
-  HH.div
-    [ HP.class_ (HH.ClassName "detail-section") ]
-    [ HH.div
-        [ HP.class_
-            (HH.ClassName "detail-heading")
-        ]
-        [ HH.text
-            ("Pull Requests (" <> show count <> ")")
-        ]
-    , if null prs then
-        HH.div
-          [ HP.class_ (HH.ClassName "empty-msg") ]
-          [ HH.text "No open pull requests" ]
-      else
-        HH.table
+  let
+    key = "section-prs"
+    isOpen = Set.member key state.expandedItems
+  in
+    HH.div
+      [ HP.class_ (HH.ClassName "detail-section") ]
+      [ HH.div
           [ HP.class_
-              (HH.ClassName "detail-table")
+              (HH.ClassName "detail-heading clickable")
+          , HE.onClick \_ -> ToggleItem key
           ]
-          [ HH.tbody_
-              (prs >>= renderPRRow state)
+          [ HH.text
+              ( (if isOpen then "\x25BE " else "\x25B8 ")
+                  <> "Pull Requests ("
+                  <> show count
+                  <> ")"
+              )
           ]
-    ]
+      , if not isOpen then HH.text ""
+        else if null prs then
+          HH.div
+            [ HP.class_ (HH.ClassName "empty-msg") ]
+            [ HH.text "No open pull requests" ]
+        else
+          HH.table
+            [ HP.class_
+                (HH.ClassName "detail-table")
+            ]
+            [ HH.tbody_
+                (prs >>= renderPRRow state)
+            ]
+      ]
 
 -- | Single PR row + optional body row.
 renderPRRow


### PR DESCRIPTION
## Summary
- Issues and PRs sections toggle independently on heading click
- Sections start collapsed, show ▸/▾ indicator