### PR TITLE
Custom repo ordering with persistence

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -57,6 +57,8 @@
     .repo-date { color: #666; font-size: 12px; white-space: nowrap; }
     .link-btn { display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 28px; border-radius: 4px; background: #252542; color: #2196f3; text-decoration: none; font-size: 14px; }
     .link-btn:hover { background: #2a2a50; color: #64b5f6; }
+    .move-btn { display: inline-flex; align-items: center; justify-content: center; width: 22px; height: 22px; border-radius: 3px; color: #666; font-size: 10px; cursor: pointer; margin-right: 2px; }
+    .move-btn:hover { background: #252542; color: #e0e0e0; }
     .detail-panel { background: #0f1525; border-bottom: 1px solid #333; }
     .detail-panel td { padding: 16px 12px; }
     .detail-section { margin-bottom: 16px; }


### PR DESCRIPTION
## Summary
- Add "Custom" sort mode with up/down arrow buttons on each repo row
- Order is persisted in localStorage across sessions
- New repos are appended to the end of the custom order