### PR TITLE
Drag-and-drop repo reordering

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -57,8 +57,9 @@
     .repo-date { color: #666; font-size: 12px; white-space: nowrap; }
     .link-btn { display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 28px; border-radius: 4px; background: #252542; color: #2196f3; text-decoration: none; font-size: 14px; }
     .link-btn:hover { background: #2a2a50; color: #64b5f6; }
-    .move-btn { display: inline-flex; align-items: center; justify-content: center; width: 22px; height: 22px; border-radius: 3px; color: #666; font-size: 10px; cursor: pointer; margin-right: 2px; }
-    .move-btn:hover { background: #252542; color: #e0e0e0; }
+    .drag-handle { cursor: grab; color: #555; font-size: 14px; padding: 10px 4px 10px 8px !important; width: 20px; user-select: none; }
+    .drag-handle:active { cursor: grabbing; }
+    .drag-handle:hover { color: #e0e0e0; }
     .detail-panel { background: #0f1525; border-bottom: 1px solid #333; }
     .detail-panel td { padding: 16px 12px; }
     .detail-section { margin-bottom: 16px; }

--- a/src/Types.purs
+++ b/src/Types.purs
@@ -15,7 +15,7 @@ import Data.Argonaut.Decode.Class (class DecodeJson)
 import Data.Argonaut.Decode.Combinators ((.:), (.:?))
 import Data.Argonaut.Decode.Error (JsonDecodeError(..))
 import Data.Either (Either(..))
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe(..), fromMaybe)
 
 -- | A label on an issue or PR.
 type Label =
@@ -92,7 +92,7 @@ instance DecodeJson Issue where
       userObj <- obj .: "user"
       userLogin_ <- userObj .: "login"
       labels_ <- obj .: "labels"
-      assignees_ <- obj .: "assignees"
+      assignees_ <- fromMaybe [] <$> obj .:? "assignees"
       body_ <- obj .:? "body"
       pure $ Issue
         { number: number_
@@ -130,7 +130,7 @@ instance DecodeJson PullRequest where
       userLogin_ <- userObj .: "login"
       draft_ <- obj .: "draft"
       labels_ <- obj .: "labels"
-      assignees_ <- obj .: "assignees"
+      assignees_ <- fromMaybe [] <$> obj .:? "assignees"
       body_ <- obj .:? "body"
       pure $ PullRequest
         { number: number_


### PR DESCRIPTION
## Summary
- Replace up/down arrow buttons with HTML5 drag and drop
- Rows become draggable when Custom sort mode is active
- Drop a repo onto another to reorder, persisted in localStorage