### PR TITLE
Add repo by URL with pinned persistence

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -35,6 +35,7 @@
     .filter-input { padding: 6px 10px; border: 1px solid #333; border-radius: 4px; background: #16213e; color: #e0e0e0; font-size: 12px; outline: none; width: 180px; }
     .filter-input:focus { border-color: #2196f3; }
     .filter-input::placeholder { color: #555; }
+    .add-repo-bar { display: flex; gap: 8px; margin-bottom: 12px; align-items: center; }
     .rate-limit { color: #666; font-size: 11px; }
     .rate-limit-warn { color: #f44336; }
     .repo-table { width: 100%; border-collapse: collapse; }

--- a/src/GitHub.purs
+++ b/src/GitHub.purs
@@ -6,6 +6,7 @@ module GitHub
   , fetchUserRepos
   , fetchRepoIssues
   , fetchRepoPRs
+  , fetchRepo
   ) where
 
 import Prelude
@@ -207,6 +208,21 @@ fetchRepoIssues token fullName = do
         r.items
     )
     result
+
+-- | Fetch a single repo by full name (owner/repo).
+fetchRepo
+  :: String
+  -> String
+  -> Aff (Either String Repo)
+fetchRepo token fullName = do
+  result <- ghFetch token
+    ( "https://api.github.com/repos/"
+        <> fullName
+    )
+  pure $ result >>= \r ->
+    case decodeJson r.json of
+      Left err -> Left (show err)
+      Right repo -> Right repo
 
 -- | Fetch open pull requests for a repo.
 fetchRepoPRs

--- a/src/View.purs
+++ b/src/View.purs
@@ -49,6 +49,9 @@ data Action
   | ToggleAutoRefresh
   | DragStart String
   | DragDrop String
+  | ToggleAddRepo
+  | SetAddRepoInput String
+  | SubmitAddRepo
   | ResetAll
 
 -- | Application state (referenced by view).
@@ -71,6 +74,8 @@ type State =
   , autoRefresh :: Boolean
   , customOrder :: Array String
   , dragging :: Maybe String
+  , showAddRepo :: Boolean
+  , addRepoInput :: String
   }
 
 -- | Token input form shown when no token is set.
@@ -148,6 +153,23 @@ renderDashboard
 renderDashboard state repos =
   HH.div_
     [ renderToolbar state
+    , if state.showAddRepo then
+        HH.div
+          [ HP.class_ (HH.ClassName "add-repo-bar") ]
+          [ HH.input
+              [ HP.placeholder "https://github.com/owner/repo"
+              , HP.value state.addRepoInput
+              , HE.onValueInput SetAddRepoInput
+              , HP.class_
+                  (HH.ClassName "filter-input")
+              ]
+          , HH.button
+              [ HE.onClick \_ -> SubmitAddRepo
+              , HP.class_ (HH.ClassName "btn-small")
+              ]
+              [ HH.text "Add" ]
+          ]
+      else HH.text ""
     , case state.error of
         Just err ->
           HH.div
@@ -177,6 +199,16 @@ renderToolbar state =
               else "\x21BB Refresh"
             )
         ]
+    , HH.button
+        [ HE.onClick \_ -> ToggleAddRepo
+        , HP.class_
+            ( HH.ClassName
+                ( "btn-back"
+                    <> activeIf state.showAddRepo
+                )
+            )
+        ]
+        [ HH.text "+" ]
     , HH.button
         [ HE.onClick \_ -> SetSort SortName
         , HP.class_


### PR DESCRIPTION
## Summary
- Add `+` button in toolbar to add repos by pasting a GitHub URL
- URL is stripped to extract owner/repo
- Added repos persist across refreshes via localStorage pinned list
- New repos prepend to custom order