### PR TITLE
feat: add delete button to repository rows

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -58,6 +58,8 @@
     .repo-date { color: #666; font-size: 12px; white-space: nowrap; }
     .link-btn { display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 28px; border-radius: 4px; background: #252542; color: #2196f3; text-decoration: none; font-size: 14px; }
     .link-btn:hover { background: #2a2a50; color: #64b5f6; }
+    .btn-remove { background: none; border: none; color: #555; font-size: 14px; cursor: pointer; padding: 4px 6px; border-radius: 4px; }
+    .btn-remove:hover { color: #f44336; background: #2a2a50; }
     .drag-handle { cursor: grab; color: #555; font-size: 14px; padding: 10px 4px 10px 8px !important; width: 20px; user-select: none; }
     .drag-handle:active { cursor: grabbing; }
     .drag-handle:hover { color: #e0e0e0; }

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -265,6 +265,26 @@ handleAction = case _ of
                 , error = Nothing
                 }
               liftEffect $ saveRepoList newList
+  RemoveRepo fullName -> do
+    st <- H.get
+    let
+      newList = filter (_ /= fullName) st.repoList
+      newRepos = filter
+        (\(Repo r) -> r.fullName /= fullName)
+        st.repos
+    H.modify_ _
+      { repoList = newList
+      , repos = newRepos
+      , expanded =
+          if st.expanded == Just fullName then
+            Nothing
+          else st.expanded
+      , details =
+          if st.expanded == Just fullName then
+            Nothing
+          else st.details
+      }
+    liftEffect $ saveRepoList newList
   ResetAll -> do
     ok <- liftEffect do
       w <- window

--- a/src/View.purs
+++ b/src/View.purs
@@ -46,6 +46,7 @@ data Action
   | ToggleAddRepo
   | SetAddRepoInput String
   | SubmitAddRepo
+  | RemoveRepo String
   | ResetAll
 
 -- | Application state (referenced by view).
@@ -305,6 +306,7 @@ renderRepoTable state repos =
             , HH.th_
                 [ HH.text "Updated" ]
             , HH.th_ []
+            , HH.th_ []
             ]
         ]
     , HH.tbody_
@@ -373,6 +375,15 @@ renderRepoRow state (Repo r) =
             ]
         , HH.td_
             [ linkButton r.htmlUrl ]
+        , HH.td_
+            [ HH.button
+                [ HE.onClick \_ -> RemoveRepo
+                    r.fullName
+                , HP.class_
+                    (HH.ClassName "btn-remove")
+                ]
+                [ HH.text "\x2715" ]
+            ]
         ]
     ]
       <>
@@ -430,7 +441,7 @@ renderDetailPanel state =
   HH.tr
     [ HP.class_ (HH.ClassName "detail-panel") ]
     [ HH.td
-        [ HP.colSpan 8 ]
+        [ HP.colSpan 9 ]
         [ if state.detailLoading then
             HH.div
               [ HP.class_


### PR DESCRIPTION
## Summary
- Add ✕ button on each repo row to remove it from the stored list
- Hover turns red for clear affordance
- Removes from both repoList and repos, collapses detail if expanded

## Test plan
- [ ] Click ✕ on a repo row, verify it disappears
- [ ] Refresh page, verify removed repo stays removed
- [ ] Re-add via + button works after deletion