### PR TITLE
feat: CI check-run details on PR expand

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -103,6 +103,9 @@
     .detail-body blockquote { border-left: 3px solid #333; padding-left: 12px; margin: 2px 0; color: #999; }
     .detail-body img { max-width: 100%; }
     .detail-row td { padding: 0 8px 8px !important; border-bottom: none !important; }
+    .check-runs { display: flex; flex-direction: column; gap: 4px; }
+    .check-run { display: flex; align-items: center; gap: 8px; font-size: 12px; }
+    .check-name { font-size: 12px; }
     .loading-spinner { color: #666; font-size: 13px; padding: 12px 0; }
     .empty-msg { color: #555; font-size: 13px; font-style: italic; }
     @keyframes pulse { 50% { opacity: 0.6; } }

--- a/src/Types.purs
+++ b/src/Types.purs
@@ -4,6 +4,7 @@ module Types
   , Issue(..)
   , PullRequest(..)
   , RepoDetail
+  , CheckRun(..)
   , Label
   , Assignee
   ) where
@@ -149,11 +150,34 @@ instance DecodeJson PullRequest where
         , headSha: headSha_
         }
 
+-- | A single CI check run.
+newtype CheckRun = CheckRun
+  { name :: String
+  , status :: String
+  , conclusion :: Maybe String
+  , htmlUrl :: String
+  }
+
+instance DecodeJson CheckRun where
+  decodeJson json = case toObject json of
+    Nothing -> Left (TypeMismatch "Object")
+    Just obj -> do
+      name_ <- obj .: "name"
+      status_ <- obj .: "status"
+      conclusion_ <- obj .:? "conclusion"
+      htmlUrl_ <- obj .: "html_url"
+      pure $ CheckRun
+        { name: name_
+        , status: status_
+        , conclusion: conclusion_
+        , htmlUrl: htmlUrl_
+        }
+
 -- | Cached detail for an expanded repo.
 type RepoDetail =
   { issues :: Array Issue
   , pullRequests :: Array PullRequest
   , issueCount :: Int
   , prCount :: Int
-  , prStatuses :: Map Int String
+  , prChecks :: Map Int (Array CheckRun)
   }


### PR DESCRIPTION
## Summary
- Add `CheckRun` newtype with decode from GitHub check-runs API
- Fetch both `/check-runs` (GitHub Actions) and `/statuses` (legacy CI like Buildkite) endpoints, merge results
- Show combined CI status badge on each PR row
- Render non-success checks in a collapsible section with status badge and build link when PR is expanded
- Skip CI fetch for hidden PRs