### PR TITLE
Replace auto-refresh with granular refresh buttons

### DIFF
--- a/src/GitHub.purs
+++ b/src/GitHub.purs
@@ -5,7 +5,9 @@ module GitHub
   , fetchAllPages
   , fetchUserRepos
   , fetchRepoIssues
+  , fetchIssue
   , fetchRepoPRs
+  , fetchPR
   , fetchRepo
   , fetchCheckRuns
   , fetchCommitStatuses
@@ -211,6 +213,24 @@ fetchRepoIssues token fullName = do
     )
     result
 
+-- | Fetch a single issue by number.
+fetchIssue
+  :: String
+  -> String
+  -> Int
+  -> Aff (Either String Issue)
+fetchIssue token fullName number = do
+  result <- ghFetch token
+    ( "https://api.github.com/repos/"
+        <> fullName
+        <> "/issues/"
+        <> show number
+    )
+  pure $ result >>= \r ->
+    case decodeJson r.json of
+      Left err -> Left (show err)
+      Right issue -> Right issue
+
 -- | Fetch a single repo by full name (owner/repo).
 fetchRepo
   :: String
@@ -238,6 +258,24 @@ fetchRepoPRs token fullName = do
         <> "/pulls?state=open&per_page=100"
     )
   pure $ map _.items result
+
+-- | Fetch a single pull request by number.
+fetchPR
+  :: String
+  -> String
+  -> Int
+  -> Aff (Either String PullRequest)
+fetchPR token fullName number = do
+  result <- ghFetch token
+    ( "https://api.github.com/repos/"
+        <> fullName
+        <> "/pulls/"
+        <> show number
+    )
+  pure $ result >>= \r ->
+    case decodeJson r.json of
+      Left err -> Left (show err)
+      Right pr -> Right pr
 
 -- | Fetch check-runs for a SHA.
 fetchCheckRuns

--- a/src/View.purs
+++ b/src/View.purs
@@ -155,42 +155,7 @@ renderToolbar state =
         , HE.onValueInput SetFilter
         , HP.class_ (HH.ClassName "filter-input")
         ]
-    , HH.div
-        [ HP.class_ (HH.ClassName "toolbar-timer") ]
-        [ HH.button
-            [ HE.onClick \_ -> ToggleAutoRefresh
-            , HP.class_
-                ( HH.ClassName
-                    ( "btn-small"
-                        <> activeIf state.autoRefresh
-                    )
-                )
-            ]
-            [ HH.text
-                ( if state.autoRefresh then
-                    "\x25B6 Auto"
-                  else "\x23F8 Paused"
-                )
-            ]
-        , HH.button
-            [ HE.onClick \_ -> ChangeInterval (-5)
-            , HP.class_ (HH.ClassName "btn-small")
-            ]
-            [ HH.text "-" ]
-        , HH.text
-            ( if state.autoRefresh then
-                show state.secondsLeft <> "s / "
-                  <> show state.interval
-                  <> "s"
-              else show state.interval <> "s"
-            )
-        , HH.button
-            [ HE.onClick \_ -> ChangeInterval 5
-            , HP.class_ (HH.ClassName "btn-small")
-            ]
-            [ HH.text "+" ]
-        , renderRateLimit state.rateLimit
-        ]
+    , renderRateLimit state.rateLimit
     , HH.a
         [ HP.href
             "https://github.com/paolino/gh-dashboard"

--- a/src/View/Types.purs
+++ b/src/View/Types.purs
@@ -12,15 +12,16 @@ import Types (Repo, RepoDetail)
 -- | Actions emitted by the view.
 data Action
   = Initialize
-  | Tick
   | SetToken String
   | SubmitToken
   | Refresh
+  | RefreshIssues
+  | RefreshIssue Int
+  | RefreshPRs
+  | RefreshPR Int
   | ToggleExpand String
   | ToggleItem String
   | SetFilter String
-  | ToggleAutoRefresh
-  | ChangeInterval Int
   | DragStart String
   | DragDrop String
   | ToggleAddRepo
@@ -40,12 +41,9 @@ type State =
   , loading :: Boolean
   , error :: Maybe String
   , rateLimit :: Maybe RateLimit
-  , interval :: Int
-  , secondsLeft :: Int
   , filterText :: String
   , hasToken :: Boolean
   , expandedItems :: Set String
-  , autoRefresh :: Boolean
   , repoList :: Array String
   , hiddenItems :: Set String
   , dragging :: Maybe String


### PR DESCRIPTION
## Summary
- Remove timer-based auto-refresh (ticker, interval controls, countdown)
- Add per-item refresh buttons on issue rows, PR rows, and section headings
- Expanding a repo no longer auto-fetches — use refresh buttons to load data
- Add `fetchIssue` and `fetchPR` endpoints for single-item refresh

## Test plan
- Verify no timer/auto-refresh UI in toolbar
- Expand a repo, use section ↻ to load issues/PRs
- Use per-PR ↻ to refresh a single PR + its checks
- Use per-issue ↻ to refresh a single issue
- Confirm refresh buttons don't toggle collapse state