### PR TITLE
Fix refresh button placement and mobile layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **[Live demo](https://paolino.github.io/gh-dashboard/)**
 
-Repository dashboard for GitHub — browse your repos, open issues and pull requests on a single page with auto-refresh, expandable detail panels and inline markdown rendering.
+Repository dashboard for GitHub — browse your repos, open issues and pull requests on a single page with granular refresh controls, expandable detail panels and inline markdown rendering.
 
 **Runs entirely in your browser.** There is no server — the app is a static page hosted on GitHub Pages. Your GitHub token is stored in localStorage and sent only to the GitHub API. Nothing is logged or transmitted to any third party.
 
@@ -13,12 +13,12 @@ Repository dashboard for GitHub — browse your repos, open issues and pull requ
 - **Repo list** — first connection seeds 15 most recently updated repos; order persists in localStorage
 - **Drag-and-drop reordering** — grab the ☰ handle to rearrange repos
 - **Add / remove repos** — `+` button to add any public or private repo by URL; ✕ button to remove
-- **Expandable detail panels** — click a repo row to load its open issues and pull requests
+- **Expandable detail panels** — click a repo row to reveal its issues and pull requests sections
+- **Granular refresh** — ↻ buttons at every level: section headings reload all issues or PRs; per-row buttons refresh a single issue or PR (including CI checks)
 - **Collapsible sections** — Issues and PRs sections expand/collapse independently
 - **Hide / unhide items** — hide individual issues or PRs; hidden items are grouped in a collapsible "Hidden" section within each group, persisted across sessions
 - **Inline markdown** — click an issue or PR to render its body as markdown
 - **Filter** — live text filter across repo names and descriptions
-- **Auto-refresh** — configurable interval (default 60s), pause/resume toggle
 - **Rate limit display** — shows remaining GitHub API quota
 - **Reset** — clears all saved data (token, repo list, hidden items)
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -25,6 +25,7 @@
     .token-link { color: #2196f3; text-decoration: none; }
     .token-link:hover { text-decoration: underline; }
     .toolbar { display: flex; gap: 8px; margin-bottom: 16px; align-items: center; flex-wrap: wrap; }
+    .toolbar-spacer { flex: 1; }
     .toolbar-timer { display: flex; align-items: center; gap: 6px; color: #666; font-size: 12px; margin-left: auto; font-variant-numeric: tabular-nums; }
     .btn-small { padding: 4px 10px; border: 1px solid #252542; border-radius: 4px; background: #252542; color: #9e9e9e; font-size: 12px; cursor: pointer; }
     .btn-small:hover { background: #2a2a50; border-color: #2a2a50; color: #e0e0e0; }
@@ -116,10 +117,10 @@
       .toolbar { gap: 6px; }
       .toolbar-timer { margin-left: 0; width: 100%; justify-content: flex-start; margin-top: 4px; }
       .filter-input { width: 100%; box-sizing: border-box; }
-      .repo-table th:nth-child(2), .repo-table td:nth-child(2),
-      .repo-table th:nth-child(3), .repo-table td:nth-child(3),
       .repo-table th:nth-child(4), .repo-table td:nth-child(4),
-      .repo-table th:nth-child(6), .repo-table td:nth-child(6) { display: none; }
+      .repo-table th:nth-child(5), .repo-table td:nth-child(5),
+      .repo-table th:nth-child(6), .repo-table td:nth-child(6),
+      .repo-table th:nth-child(7), .repo-table td:nth-child(7) { display: none; }
       .link-btn { width: 24px; height: 24px; font-size: 12px; }
       .repo-row td { padding: 8px 6px; }
       .repo-table th { padding: 6px; }

--- a/src/View.purs
+++ b/src/View.purs
@@ -124,22 +124,13 @@ renderDashboard state repos =
         renderRepoTable state repos
     ]
 
--- | Toolbar with refresh, timer, filter.
+-- | Toolbar with filter and controls.
 renderToolbar
   :: forall w. State -> HH.HTML w Action
 renderToolbar state =
   HH.div
     [ HP.class_ (HH.ClassName "toolbar") ]
     [ HH.button
-        [ HE.onClick \_ -> Refresh
-        , HP.class_ (HH.ClassName "btn-back")
-        ]
-        [ HH.text
-            ( if state.loading then "\x21BB ..."
-              else "\x21BB Refresh"
-            )
-        ]
-    , HH.button
         [ HE.onClick \_ -> ToggleAddRepo
         , HP.class_
             ( HH.ClassName
@@ -156,18 +147,29 @@ renderToolbar state =
         , HP.class_ (HH.ClassName "filter-input")
         ]
     , renderRateLimit state.rateLimit
+    , HH.div
+        [ HP.class_
+            (HH.ClassName "toolbar-spacer")
+        ]
+        []
     , HH.a
         [ HP.href
             "https://github.com/paolino/gh-dashboard"
         , HP.target "_blank"
-        , HP.class_ (HH.ClassName "btn-small")
+        , HP.class_ (HH.ClassName "link-btn")
         ]
-        [ HH.text "\x2605 GitHub" ]
+        [ HH.img
+            [ HP.src
+                "https://github.githubassets.com/favicons/favicon-dark.svg"
+            , HP.width 16
+            , HP.height 16
+            ]
+        ]
     , HH.button
         [ HE.onClick \_ -> ResetAll
-        , HP.class_ (HH.ClassName "btn-small")
+        , HP.class_ (HH.ClassName "btn-hide")
         ]
-        [ HH.text "\x2715 Reset" ]
+        [ HH.text "\x2620" ]
     ]
 
 activeIf :: Boolean -> String

--- a/src/View/Detail.purs
+++ b/src/View/Detail.purs
@@ -31,7 +31,7 @@ renderDetailPanel state =
   HH.tr
     [ HP.class_ (HH.ClassName "detail-panel") ]
     [ HH.td
-        [ HP.colSpan 9 ]
+        [ HP.colSpan 10 ]
         [ if state.detailLoading then
             HH.div
               [ HP.class_
@@ -191,6 +191,10 @@ renderIssueRow state isHidden (Issue i) =
         , HP.class_ (HH.ClassName "repo-row")
         ]
         [ HH.td_
+            [ refreshButton
+                (RefreshIssue i.number)
+            ]
+        , HH.td_
             [ HH.span
                 [ HP.class_
                     (HH.ClassName "detail-link")
@@ -373,6 +377,10 @@ renderPRRow state isHidden (PullRequest pr) =
         , HP.class_ (HH.ClassName "repo-row")
         ]
         [ HH.td_
+            [ refreshButton
+                (RefreshPR pr.number)
+            ]
+        , HH.td_
             ( [ HH.span
                   [ HP.class_
                       (HH.ClassName "detail-link")

--- a/src/View/RepoTable.purs
+++ b/src/View/RepoTable.purs
@@ -27,6 +27,7 @@ renderRepoTable state repos =
     [ HH.thead_
         [ HH.tr_
             [ HH.th_ []
+            , HH.th_ []
             , HH.th_
                 [ HH.text "Repository" ]
             , HH.th_
@@ -73,6 +74,17 @@ renderRepoRow state (Repo r) =
             ]
             [ HH.text "\x2630" ]
         , HH.td_
+            [ HH.button
+                [ HE.onClick \_ ->
+                    RefreshRepo r.fullName
+                , HP.class_
+                    (HH.ClassName "btn-hide")
+                , HP.attr (AttrName "onclick")
+                    "event.stopPropagation()"
+                ]
+                [ HH.text "\x21BB" ]
+            ]
+        , HH.td_
             [ HH.span
                 [ HP.class_
                     (HH.ClassName "repo-name")
@@ -113,7 +125,7 @@ renderRepoRow state (Repo r) =
                 , HP.class_
                     (HH.ClassName "btn-remove")
                 ]
-                [ HH.text "\x2715" ]
+                [ HH.text "\xD83D\xDDD1" ]
             ]
         ]
     ]

--- a/src/View/Types.purs
+++ b/src/View/Types.purs
@@ -14,7 +14,7 @@ data Action
   = Initialize
   | SetToken String
   | SubmitToken
-  | Refresh
+  | RefreshRepo String
   | RefreshIssues
   | RefreshIssue Int
   | RefreshPRs


### PR DESCRIPTION
## Summary
- Move per-item refresh buttons to left column
- Keep repo names visible on small screens (hide description, lang, visibility instead)

## Test plan
- Verify refresh ↻ buttons appear as first column in issue/PR rows
- Resize browser to mobile width: repo names should remain visible