### PR TITLE
feat: import/export settings

### DIFF
--- a/src/FFI/Storage.js
+++ b/src/FFI/Storage.js
@@ -1,0 +1,50 @@
+const KEYS = [
+  "gh-dashboard-repos",
+  "gh-dashboard-hidden",
+  "gh-dashboard-dark-theme",
+  "gh-dashboard-issue-labels",
+  "gh-dashboard-pr-labels",
+];
+
+export const exportStorage = () => {
+  const data = {};
+  for (const key of KEYS) {
+    const val = localStorage.getItem(key);
+    if (val !== null) data[key] = val;
+  }
+  const blob = new Blob([JSON.stringify(data, null, 2)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "gh-dashboard-settings.json";
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
+export const importStorage = () => {
+  const input = document.createElement("input");
+  input.type = "file";
+  input.accept = ".json,application/json";
+  input.addEventListener("change", () => {
+    const file = input.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const data = JSON.parse(reader.result);
+        for (const key of KEYS) {
+          if (key in data) {
+            localStorage.setItem(key, data[key]);
+          }
+        }
+        location.reload();
+      } catch (_) {
+        alert("Invalid settings file");
+      }
+    };
+    reader.readAsText(file);
+  });
+  input.click();
+};

--- a/src/FFI/Storage.purs
+++ b/src/FFI/Storage.purs
@@ -1,0 +1,15 @@
+-- | FFI for exporting and importing dashboard settings.
+module FFI.Storage
+  ( exportStorage
+  , importStorage
+  ) where
+
+import Prelude
+
+import Effect (Effect)
+
+-- | Download all non-token settings as a JSON file.
+foreign import exportStorage :: Effect Unit
+
+-- | Open a file picker, parse the JSON, restore settings, reload.
+foreign import importStorage :: Effect Unit

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -25,6 +25,7 @@ import Halogen as H
 import Halogen.Aff as HA
 import Halogen.VDom.Driver (runUI)
 import FFI.Clipboard (copyToClipboard)
+import FFI.Storage as FFIStorage
 import FFI.Theme (setBodyTheme)
 import Refresh (doRefresh, refreshSinglePR)
 import RepoUtils
@@ -503,6 +504,10 @@ handleAction = case _ of
     liftEffect do
       saveTheme dark
       setBodyTheme dark
+  ExportStorage ->
+    liftEffect FFIStorage.exportStorage
+  ImportStorage ->
+    liftEffect FFIStorage.importStorage
   ResetAll -> do
     ok <- liftEffect do
       w <- window

--- a/src/View.purs
+++ b/src/View.purs
@@ -179,6 +179,18 @@ renderToolbar state =
             ]
         ]
     , HH.button
+        [ HE.onClick \_ -> ExportStorage
+        , HP.class_ (HH.ClassName "btn-hide")
+        , HP.title "Export settings"
+        ]
+        [ HH.text "\x2B07" ]
+    , HH.button
+        [ HE.onClick \_ -> ImportStorage
+        , HP.class_ (HH.ClassName "btn-hide")
+        , HP.title "Import settings"
+        ]
+        [ HH.text "\x2B06" ]
+    , HH.button
         [ HE.onClick \_ -> ResetAll
         , HP.class_ (HH.ClassName "btn-hide")
         , HP.title "Reset all data"

--- a/src/View/Types.purs
+++ b/src/View/Types.purs
@@ -33,6 +33,8 @@ data Action
   | ToggleIssueLabelFilter String
   | TogglePRLabelFilter String
   | ToggleTheme
+  | ExportStorage
+  | ImportStorage
   | ResetAll
 
 -- | Application state (referenced by view).


### PR DESCRIPTION
## Summary

- Add export/import buttons to the toolbar for backing up and restoring dashboard settings
- Export downloads a JSON file with repos, hidden items, theme, and label filters
- Import reads a JSON file, restores settings, and reloads the page
- Token is excluded from export/import for security