### PR TITLE
feat: add copy buttons to projects view

### DIFF
--- a/src/View/Projects.purs
+++ b/src/View/Projects.purs
@@ -579,19 +579,7 @@ renderItemRow state projId mSf (ProjectItem item) =
                             "#" <> show n <> " "
                           Nothing -> ""
                       )
-                  , case item.url of
-                      Just url ->
-                        HH.a
-                          [ HP.href url
-                          , HP.target "_blank"
-                          , HP.class_
-                              ( HH.ClassName
-                                  "detail-link"
-                              )
-                          ]
-                          [ HH.text item.title ]
-                      Nothing ->
-                        HH.text item.title
+                  , HH.text item.title
                   ]
               , if null item.labels then
                   HH.text ""


### PR DESCRIPTION
## Summary
- Add copy-to-clipboard button on project rows (copies project URL)
- Add copy-to-clipboard button on project item rows (copies item URL for issues/PRs, title for drafts)
- Reuses existing `copyButton` from `DetailWidgets`

Closes #33