### PR TITLE
feat: inline rename for projects

### DIFF
--- a/src/GitHub.purs
+++ b/src/GitHub.purs
@@ -20,6 +20,7 @@ module GitHub
   , addDraftItem
   , updateDraftItem
   , deleteProjectItem
+  , renameProject
   ) where
 
 import Prelude
@@ -940,6 +941,33 @@ updateDraftItem token draftId title = do
         draftIssueId: $draftIssueId
         title: $title
       }) { draftIssue { id } }
+    }
+    """
+    vars
+  case result of
+    Left err -> pure $ Left err
+    Right _ -> pure $ Right unit
+
+-- | Rename a project.
+renameProject
+  :: String
+  -> String
+  -> String
+  -> Aff (Either String Unit)
+renameProject token projectId title = do
+  let
+    vars = encodeJson
+      ( "projectId" := projectId
+          ~> "title" := title
+          ~> jsonEmptyObject
+      )
+  result <- ghGraphQL token
+    """
+    mutation($projectId: ID!, $title: String!) {
+      updateProjectV2(input: {
+        projectId: $projectId
+        title: $title
+      }) { projectV2 { id } }
     }
     """
     vars

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -29,6 +29,7 @@ import GitHub
   , addDraftItem
   , updateDraftItem
   , deleteProjectItem
+  , renameProject
   )
 import Halogen as H
 import Halogen.Aff as HA
@@ -57,6 +58,7 @@ import Storage
 import Types
   ( Issue(..)
   , Page(..)
+  , Project(..)
   , ProjectItem(..)
   , PullRequest(..)
   , Repo(..)
@@ -120,6 +122,8 @@ initialState =
   , newItemTitle: ""
   , editingItem: Nothing
   , editItemTitle: ""
+  , editingProject: Nothing
+  , editProjectTitle: ""
   }
 
 render :: forall m. State -> H.ComponentHTML Action () m
@@ -913,6 +917,35 @@ handleAction = case _ of
               }
       result <- H.liftAff $
         deleteProjectItem st.token projectId itemId
+      case result of
+        Left err ->
+          H.modify_ _ { error = Just err }
+        Right _ -> pure unit
+  StartRenameProject projectId currentTitle ->
+    H.modify_ _
+      { editingProject = Just projectId
+      , editProjectTitle = currentTitle
+      }
+  SetRenameProjectTitle t ->
+    H.modify_ _ { editProjectTitle = t }
+  SubmitRenameProject projectId newTitle -> do
+    st <- H.get
+    H.modify_ _
+      { editingProject = Nothing
+      , editProjectTitle = ""
+      }
+    when (newTitle /= "") do
+      let
+        updated = map
+          ( \(Project proj) ->
+              if proj.id == projectId then
+                Project proj { title = newTitle }
+              else Project proj
+          )
+          st.projects
+      H.modify_ _ { projects = updated }
+      result <- H.liftAff $
+        renameProject st.token projectId newTitle
       case result of
         Left err ->
           H.modify_ _ { error = Just err }

--- a/src/View/Projects.purs
+++ b/src/View/Projects.purs
@@ -81,6 +81,8 @@ renderProjectRow state (Project p) =
   let
     isExpanded =
       state.expandedProject == Just p.id
+    isEditing =
+      state.editingProject == Just p.id
     rowClass =
       if isExpanded then "repo-row expanded"
       else "repo-row"
@@ -101,14 +103,58 @@ renderProjectRow state (Project p) =
                     "event.stopPropagation()"
                 ]
                 [ HH.text "\x21BB" ]
-            ]
-        , HH.td_
-            [ HH.span
+            , HH.button
                 [ HP.class_
-                    (HH.ClassName "repo-name")
+                    (HH.ClassName "btn-hide")
+                , HP.title "Rename"
+                , HE.onClick \_ ->
+                    StartRenameProject p.id p.title
+                , HP.attr (AttrName "onclick")
+                    "event.stopPropagation()"
                 ]
-                [ HH.text p.title ]
+                [ HH.text "\x270E" ]
             ]
+        , if isEditing then
+            HH.td_
+              [ HH.div
+                  [ HP.class_
+                      (HH.ClassName "add-repo-bar")
+                  ]
+                  [ HH.input
+                      [ HP.type_ HP.InputText
+                      , HP.value
+                          state.editProjectTitle
+                      , HP.class_
+                          ( HH.ClassName
+                              "filter-input"
+                          )
+                      , HE.onValueInput
+                          SetRenameProjectTitle
+                      , HP.attr
+                          (AttrName "onclick")
+                          "event.stopPropagation()"
+                      ]
+                  , HH.button
+                      [ HP.class_
+                          (HH.ClassName "btn-small")
+                      , HE.onClick \_ ->
+                          SubmitRenameProject p.id
+                            state.editProjectTitle
+                      , HP.attr
+                          (AttrName "onclick")
+                          "event.stopPropagation()"
+                      ]
+                      [ HH.text "Save" ]
+                  ]
+              ]
+          else
+            HH.td_
+              [ HH.span
+                  [ HP.class_
+                      (HH.ClassName "repo-name")
+                  ]
+                  [ HH.text p.title ]
+              ]
         , HH.td_
             [ HH.span
                 [ HP.class_

--- a/src/View/Types.purs
+++ b/src/View/Types.purs
@@ -61,6 +61,9 @@ data Action
   | SetEditItemTitle String
   | SubmitEditItem String String String
   | DeleteItem String String
+  | StartRenameProject String String
+  | SetRenameProjectTitle String
+  | SubmitRenameProject String String
 
 -- | Application state (referenced by view).
 type State =
@@ -98,4 +101,6 @@ type State =
   , newItemTitle :: String
   , editingItem :: Maybe String
   , editItemTitle :: String
+  , editingProject :: Maybe String
+  , editProjectTitle :: String
   }


### PR DESCRIPTION
## Summary
- Add rename button (✎) on project rows
- Inline edit form replaces title when editing (same pattern as draft item editing)
- Optimistic UI update + `updateProjectV2` GraphQL mutation
- New `renameProject` function in GitHub module

Closes #34