### PR TITLE
feat: add reset token button

### DIFF
--- a/src/Main.purs
+++ b/src/Main.purs
@@ -87,6 +87,7 @@ import Refresh (doRefresh)
 import RepoUtils (applyFilter)
 import Storage
   ( clearAll
+  , clearToken
   , loadAgentServer
   , loadRepoList
   , loadToken
@@ -343,6 +344,17 @@ handleAction = case _ of
 
   ImportStorage ->
     liftEffect FFIStorage.importStorage
+
+  ResetToken -> do
+    ok <- liftEffect do
+      w <- window
+      confirm "Reset token?" w
+    when ok do
+      liftEffect clearToken
+      H.modify_ _
+        { token = ""
+        , hasToken = false
+        }
 
   ResetAll -> do
     ok <- liftEffect do

--- a/src/Storage.purs
+++ b/src/Storage.purs
@@ -10,6 +10,7 @@ module Storage
   , defaultViewState
   , loadAgentServer
   , saveAgentServer
+  , clearToken
   , clearAll
   ) where
 
@@ -248,6 +249,12 @@ saveAgentServer url = do
 
 storageKeyCryptoKey :: String
 storageKeyCryptoKey = "gh-dashboard-crypto-key"
+
+clearToken :: Effect Unit
+clearToken = do
+  w <- window
+  s <- localStorage w
+  Storage.removeItem storageKeyToken s
 
 clearAll :: Effect Unit
 clearAll = do

--- a/src/View.purs
+++ b/src/View.purs
@@ -260,6 +260,12 @@ renderToolbar state =
         ]
         [ HH.text "\x2B06" ]
     , HH.button
+        [ HE.onClick \_ -> ResetToken
+        , HP.class_ (HH.ClassName "btn-hide")
+        , HP.title "Reset token"
+        ]
+        [ HH.text "\x1F511" ]
+    , HH.button
         [ HE.onClick \_ -> ResetAll
         , HP.class_ (HH.ClassName "btn-hide")
         , HP.title "Reset all data"

--- a/src/View/Types.purs
+++ b/src/View/Types.purs
@@ -59,6 +59,7 @@ data Action
   | ToggleTheme
   | ExportStorage
   | ImportStorage
+  | ResetToken
   | ResetAll
   | SwitchPage Page
   | RefreshProjects


### PR DESCRIPTION
## Summary
- Add a 🔑 button in the toolbar to clear only the token
- Confirms before clearing, leaves all other state intact (repos, view, filters, theme)

Closes #40