### PR TITLE
docs: update README, metadata and HTML description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,33 +4,52 @@
 
 **[Live demo](https://lambdasistemi.github.io/gh-dashboard/)**
 
-Repository dashboard for GitHub — browse your repos, open issues and pull requests on a single page with granular refresh controls, expandable detail panels and inline markdown rendering.
-
-**Runs entirely in your browser.** There is no server — the app is a static page hosted on GitHub Pages. Your GitHub token is stored in localStorage and sent only to the GitHub API. Nothing is logged or transmitted to any third party.
+Client-side GitHub dashboard — browse repos, issues, pull requests and projects on a single page. Runs entirely in the browser as a static page on GitHub Pages. Your token stays in localStorage and is sent only to the GitHub API.
 
 ## Features
 
-- **Repo list** — first connection seeds 25 most recently updated repos; order persists in localStorage
-- **Drag-and-drop reordering** — grab the ☰ handle to rearrange repos
-- **Add / remove repos** — `+` button to add any public or private repo by URL; trash button to remove
-- **Expandable detail panels** — click a repo row to reveal its issues and pull requests sections
-- **Granular refresh** — ↻ buttons at every level: section headings reload all issues or PRs; per-row buttons refresh a single issue or PR (including CI checks)
-- **Progressive PR loading** — PRs appear one at a time as their CI check runs are fetched
-- **Collapsible sections** — Issues and PRs sections expand/collapse independently; expanding an empty section auto-triggers a refresh
-- **Hide / unhide items** — hide individual issues or PRs; hidden items are grouped in a collapsible "Hidden" section within each group, persisted across sessions
-- **Label filtering** — clickable label selector per section (issues and PRs independently); multi-select with OR logic; persisted in localStorage
-- **CI status filtering** — PR check run statuses (success, failure, pending) appear as filterable labels alongside regular labels
-- **Inline markdown** — click an issue or PR to render its body as markdown
-- **Copy to clipboard** — copy issue/PR titles with one click
-- **Filter** — live text filter across repo names and descriptions
-- **Dark / light theme** — toggle between dark and light themes; persisted in localStorage
-- **Tooltips** — hover any icon for a description of its action
-- **Rate limit display** — shows remaining GitHub API quota
-- **Import / export settings** — download all dashboard settings as JSON; import from file to restore (token excluded for security)
-- **Reset** — clears all saved data (token, repo list, hidden items, theme, filters)
-- **Agent daemon integration** — launch, detach and stop [agent-daemon](https://github.com/lambdasistemi/agent-daemon) sessions from issue and project item rows; inline xterm.js terminal replaces the description body with a live terminal connected via WebSocket
-- **Resizable terminals** — drag the handle below each terminal to adjust its height
-- **Active terminal highlighting** — issue rows with a running terminal get a blue accent border and title
+### Repositories
+
+- First connection seeds the 25 most recently updated repos; order persists in localStorage
+- Drag-and-drop reordering via ☰ handle
+- Add any public or private repo by URL; remove with the trash button
+- Live text filter across repo names and descriptions
+
+### Issues & Pull Requests
+
+- Expandable detail panels per repo with independent Issues and PRs sections
+- Granular refresh — ↻ at section level reloads all; per-row buttons refresh a single item (including CI checks)
+- Progressive PR loading — PRs appear one at a time as CI checks are fetched
+- Collapsible sections — expanding an empty section auto-triggers a refresh
+- Hide / unhide items — hidden items grouped in a collapsible "Hidden" section, persisted across sessions
+- Label filtering — multi-select with OR logic, persisted in localStorage
+- CI status filtering — check run statuses (success, failure, pending) as filterable labels
+- Inline markdown rendering for issue and PR bodies
+- Copy titles to clipboard
+
+### GitHub Projects
+
+- Dedicated Projects tab with read/write support
+- Add, update and delete project items
+- Inline rename for projects
+- Status management (Todo, In Progress, Done, Backlog)
+- Copy project item titles to clipboard
+
+### Agent Daemon
+
+- Launch, detach and stop [agent-daemon](https://github.com/lambdasistemi/agent-daemon) sessions from issue and project item rows
+- Inline xterm.js terminal replaces the description body with a live WebSocket-connected terminal
+- Resizable terminals — drag the handle below each terminal to adjust height
+- Active terminal highlighting — rows with a running terminal get a blue accent border
+
+### UI
+
+- Dark / light theme toggle, persisted in localStorage
+- Tooltips on all action icons
+- Rate limit display showing remaining GitHub API quota
+- Import / export settings as JSON (token excluded for security)
+- Reset button clears all saved data
+- Responsive design — mobile-friendly layout
 
 ## Token scopes
 
@@ -43,7 +62,7 @@ Create a [personal access token](https://github.com/settings/tokens/new?scopes=r
 
 ## Stack
 
-PureScript · Halogen · GitHub REST API · marked.js · xterm.js · esbuild
+PureScript · Halogen · GitHub REST & GraphQL API · marked.js · xterm.js · esbuild · Nix
 
 ## Development
 
@@ -63,6 +82,7 @@ just format   # format sources with purs-tidy
 just lint     # check formatting
 just ci       # lint + build + bundle
 just serve    # bundle and serve on port 10001
+just restart  # bundle, kill old server, serve
 just clean    # remove build artifacts
 ```
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Client-side GitHub dashboard — browse repos, issues, pull requests and projects on a single page">
   <title>GH Dashboard</title>
   <style>
     body {


### PR DESCRIPTION
## Summary
- Restructure README features into categorized sections (Repos, Issues & PRs, Projects, Agent Daemon, UI)
- Add missing features: GitHub Projects tab, GraphQL API, restart recipe
- Update repo description and fix homepage URL (was pointing to paolino.github.io)
- Add topics: github-projects, nix, esbuild, client-side, xterm-js
- Add meta description to index.html