### PR TITLE
fix: unify terminal and detail panel background colors

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -171,7 +171,7 @@
     .detail-body a { color: var(--accent); }
     .detail-body blockquote { border-left: 3px solid var(--border); padding-left: 12px; margin: 2px 0; color: var(--text-muted); }
     .detail-body img { max-width: 100%; }
-    .terminal-container { height: 400px; background: #1a1a2e; border-radius: 4px; overflow: hidden; position: relative; }
+    .terminal-container { height: 400px; background: var(--detail-bg); border-radius: 4px; overflow: hidden; position: relative; }
     .terminal-container .xterm { height: 100%; }
     .terminal-resize-handle { height: 6px; cursor: ns-resize; background: var(--border); border-radius: 0 0 4px 4px; }
     .terminal-resize-handle:hover { background: var(--accent); }

--- a/src/FFI/Terminal.js
+++ b/src/FFI/Terminal.js
@@ -25,7 +25,7 @@ export const attachTerminal = (elemId) => (launchKey) => (wsUrl) => () => {
       cursorBlink: true,
       fontSize: 13,
       theme: {
-        background: '#080c16',
+        background: '#0f1525',
         foreground: '#e0e0e0',
         cursor: '#e94560'
       }


### PR DESCRIPTION
## Summary
- Terminal container CSS now uses `var(--detail-bg)` instead of hardcoded `#1a1a2e`
- xterm.js theme background changed from `#080c16` to `#0f1525` to match `--detail-bg`

Closes #48