### PR TITLE
feat: encrypt token and include in export/import

### DIFF
--- a/spago.lock
+++ b/spago.lock
@@ -17,6 +17,8 @@
             "foreign-object",
             "halogen",
             "integers",
+            "js-promise",
+            "js-promise-aff",
             "maybe",
             "ordered-collections",
             "prelude",

--- a/spago.yaml
+++ b/spago.yaml
@@ -20,6 +20,8 @@ package:
     - integers
     - foreign-object
     - ordered-collections
+    - js-promise
+    - js-promise-aff
   bundle:
     module: Main
     outfile: dist/index.js

--- a/src/FFI/Storage.js
+++ b/src/FFI/Storage.js
@@ -1,37 +1,213 @@
+// --- Crypto helpers (AES-256-GCM) ---
+
+const te = new TextEncoder();
+const td = new TextDecoder();
+
+function toBase64(buf) {
+  return btoa(String.fromCharCode(...new Uint8Array(buf)));
+}
+
+function fromBase64(str) {
+  return Uint8Array.from(atob(str), (c) => c.charCodeAt(0));
+}
+
+// Generate or load a random AES key for at-rest encryption.
+async function getLocalKey() {
+  const stored = localStorage.getItem(
+    "gh-dashboard-crypto-key"
+  );
+  if (stored) {
+    return crypto.subtle.importKey(
+      "jwk",
+      JSON.parse(stored),
+      { name: "AES-GCM" },
+      true,
+      ["encrypt", "decrypt"]
+    );
+  }
+  const key = await crypto.subtle.generateKey(
+    { name: "AES-GCM", length: 256 },
+    true,
+    ["encrypt", "decrypt"]
+  );
+  const jwk = await crypto.subtle.exportKey("jwk", key);
+  localStorage.setItem(
+    "gh-dashboard-crypto-key",
+    JSON.stringify(jwk)
+  );
+  return key;
+}
+
+// Encrypt with the local random key (at-rest).
+// Returns base64(iv12 + ciphertext).
+async function encryptLocal(plaintext) {
+  const key = await getLocalKey();
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ct = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    te.encode(plaintext)
+  );
+  const buf = new Uint8Array(iv.length + ct.byteLength);
+  buf.set(iv, 0);
+  buf.set(new Uint8Array(ct), iv.length);
+  return toBase64(buf);
+}
+
+// Decrypt with the local random key (at-rest).
+async function decryptLocal(blob) {
+  const key = await getLocalKey();
+  const data = fromBase64(blob);
+  const iv = data.slice(0, 12);
+  const ct = data.slice(12);
+  const pt = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv },
+    key,
+    ct
+  );
+  return td.decode(pt);
+}
+
+// Derive an AES key from a passphrase via PBKDF2.
+async function deriveKey(passphrase, salt) {
+  const km = await crypto.subtle.importKey(
+    "raw",
+    te.encode(passphrase),
+    "PBKDF2",
+    false,
+    ["deriveKey"]
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt,
+      iterations: 100000,
+      hash: "SHA-256",
+    },
+    km,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"]
+  );
+}
+
+// Encrypt with a user passphrase (for export).
+// Returns base64(salt16 + iv12 + ciphertext).
+async function encryptPassphrase(plaintext, passphrase) {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const key = await deriveKey(passphrase, salt);
+  const ct = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    te.encode(plaintext)
+  );
+  const buf = new Uint8Array(
+    salt.length + iv.length + ct.byteLength
+  );
+  buf.set(salt, 0);
+  buf.set(iv, salt.length);
+  buf.set(new Uint8Array(ct), salt.length + iv.length);
+  return toBase64(buf);
+}
+
+// Decrypt with a user passphrase (for import).
+async function decryptPassphrase(blob, passphrase) {
+  const data = fromBase64(blob);
+  const salt = data.slice(0, 16);
+  const iv = data.slice(16, 28);
+  const ct = data.slice(28);
+  const key = await deriveKey(passphrase, salt);
+  const pt = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv },
+    key,
+    ct
+  );
+  return td.decode(pt);
+}
+
+// --- Token storage (encrypted at rest) ---
+
+export const saveTokenEncrypted = (token) => () =>
+  encryptLocal(token).then((enc) =>
+    localStorage.setItem("gh-dashboard-token", enc)
+  );
+
+export const loadTokenEncrypted = () => {
+  const raw = localStorage.getItem("gh-dashboard-token");
+  if (!raw) return Promise.resolve("");
+  return decryptLocal(raw).catch(() => {
+    // Migration: plaintext token from before encryption.
+    // Re-encrypt and store, return the original value.
+    return encryptLocal(raw).then((enc) => {
+      localStorage.setItem("gh-dashboard-token", enc);
+      return raw;
+    });
+  });
+};
+
+// --- Settings keys (non-token) ---
+
 const KEYS = [
   "gh-dashboard-repos",
   "gh-dashboard-hidden",
   "gh-dashboard-dark-theme",
   "gh-dashboard-issue-labels",
   "gh-dashboard-pr-labels",
+  "gh-dashboard-view",
 ];
 
+// --- Export / Import ---
+
 export const exportStorage = () => {
-  const data = {};
-  for (const key of KEYS) {
-    const val = localStorage.getItem(key);
-    if (val !== null) data[key] = val;
-  }
-  const blob = new Blob([JSON.stringify(data, null, 2)], {
-    type: "application/json",
-  });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = "gh-dashboard-settings.json";
-  a.click();
-  URL.revokeObjectURL(url);
+  (async () => {
+    const data = {};
+    for (const key of KEYS) {
+      const val = localStorage.getItem(key);
+      if (val !== null) data[key] = val;
+    }
+    // Include token encrypted with a passphrase
+    const rawToken = localStorage.getItem(
+      "gh-dashboard-token"
+    );
+    if (rawToken) {
+      let token;
+      try {
+        token = await decryptLocal(rawToken);
+      } catch {
+        // Pre-encryption plaintext token
+        token = rawToken;
+      }
+      const passphrase = prompt(
+        "Enter a passphrase to protect your token in the export file:"
+      );
+      if (passphrase) {
+        data["gh-dashboard-token"] =
+          await encryptPassphrase(token, passphrase);
+      }
+    }
+    const blob = new Blob(
+      [JSON.stringify(data, null, 2)],
+      { type: "application/json" }
+    );
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "gh-dashboard-settings.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  })();
 };
 
 export const importStorage = () => {
   const input = document.createElement("input");
   input.type = "file";
   input.accept = ".json,application/json";
-  input.addEventListener("change", () => {
+  input.addEventListener("change", async () => {
     const file = input.files[0];
     if (!file) return;
     const reader = new FileReader();
-    reader.onload = () => {
+    reader.onload = async () => {
       try {
         const data = JSON.parse(reader.result);
         for (const key of KEYS) {
@@ -39,8 +215,32 @@ export const importStorage = () => {
             localStorage.setItem(key, data[key]);
           }
         }
+        // Decrypt token with passphrase, re-encrypt for
+        // local storage
+        if ("gh-dashboard-token" in data) {
+          const passphrase = prompt(
+            "Enter the passphrase to decrypt your token:"
+          );
+          if (passphrase) {
+            try {
+              const token = await decryptPassphrase(
+                data["gh-dashboard-token"],
+                passphrase
+              );
+              const enc = await encryptLocal(token);
+              localStorage.setItem(
+                "gh-dashboard-token",
+                enc
+              );
+            } catch {
+              alert(
+                "Wrong passphrase or corrupted token data"
+              );
+            }
+          }
+        }
         location.reload();
-      } catch (_) {
+      } catch {
         alert("Invalid settings file");
       }
     };

--- a/src/FFI/Storage.purs
+++ b/src/FFI/Storage.purs
@@ -1,15 +1,31 @@
--- | FFI for exporting and importing dashboard settings.
+-- | FFI for exporting/importing dashboard settings and
+-- | encrypted token storage.
 module FFI.Storage
   ( exportStorage
   , importStorage
+  , saveTokenEncrypted
+  , loadTokenEncrypted
   ) where
 
 import Prelude
 
 import Effect (Effect)
+import Promise (Promise)
 
--- | Download all non-token settings as a JSON file.
+-- | Download all settings (including passphrase-encrypted
+-- | token) as a JSON file.
 foreign import exportStorage :: Effect Unit
 
--- | Open a file picker, parse the JSON, restore settings, reload.
+-- | Open a file picker, parse the JSON, restore settings
+-- | (decrypting token with passphrase), reload.
 foreign import importStorage :: Effect Unit
+
+-- | Encrypt a token with a random local key and store it.
+foreign import saveTokenEncrypted
+  :: String -> Effect (Promise Unit)
+
+-- | Load and decrypt the token from localStorage.
+-- | Returns empty string if no token is stored.
+-- | Handles migration from plaintext tokens.
+foreign import loadTokenEncrypted
+  :: Effect (Promise String)

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -195,7 +195,7 @@ handleAction = case _ of
   ------------------------------------------------
 
   Initialize -> do
-    saved <- liftEffect loadToken
+    saved <- H.liftAff loadToken
     repoList <- liftEffect loadRepoList
     agentUrl <- liftEffect loadAgentServer
     vs <- liftEffect loadViewState
@@ -241,7 +241,7 @@ handleAction = case _ of
       H.modify_ _
         { error = Just "Please enter a token" }
     else do
-      liftEffect $ saveToken st.token
+      H.liftAff $ saveToken st.token
       H.modify_ _
         { hasToken = true
         , error = Nothing

--- a/src/Storage.purs
+++ b/src/Storage.purs
@@ -27,8 +27,11 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Tuple.Nested ((/\))
 import Data.Set as Set
 import Effect (Effect)
+import Effect.Aff (Aff)
+import FFI.Storage as FFIStorage
 import Foreign.Object as FO
 import Data.Argonaut.Core as Json
+import Promise.Aff (toAffE)
 import Types (Page(..))
 import Web.HTML (window)
 import Web.HTML.Window (localStorage)
@@ -73,17 +76,14 @@ storageKeyRepos = "gh-dashboard-repos"
 storageKeyView :: String
 storageKeyView = "gh-dashboard-view"
 
-loadToken :: Effect String
-loadToken = do
-  w <- window
-  s <- localStorage w
-  fromMaybe "" <$> Storage.getItem storageKeyToken s
+-- | Load and decrypt the token from localStorage.
+-- | Handles migration from pre-encryption plaintext tokens.
+loadToken :: Aff String
+loadToken = toAffE FFIStorage.loadTokenEncrypted
 
-saveToken :: String -> Effect Unit
-saveToken tok = do
-  w <- window
-  s <- localStorage w
-  Storage.setItem storageKeyToken tok s
+-- | Encrypt and store the token in localStorage.
+saveToken :: String -> Aff Unit
+saveToken tok = toAffE (FFIStorage.saveTokenEncrypted tok)
 
 loadRepoList :: Effect (Array String)
 loadRepoList = do
@@ -246,6 +246,9 @@ saveAgentServer url = do
   s <- localStorage w
   Storage.setItem storageKeyAgentServer url s
 
+storageKeyCryptoKey :: String
+storageKeyCryptoKey = "gh-dashboard-crypto-key"
+
 clearAll :: Effect Unit
 clearAll = do
   w <- window
@@ -253,3 +256,4 @@ clearAll = do
   Storage.removeItem storageKeyToken s
   Storage.removeItem storageKeyRepos s
   Storage.removeItem storageKeyView s
+  Storage.removeItem storageKeyCryptoKey s


### PR DESCRIPTION
## Summary
- Token encrypted at rest in localStorage (AES-256-GCM with random local key)
- Export prompts for passphrase, encrypts token with PBKDF2-derived key
- Import prompts for passphrase, decrypts and re-encrypts for local storage
- KEYS list updated to include `gh-dashboard-view`
- Transparent migration from plaintext tokens
- Crypto key cleared on reset

Closes #39