### PR TITLE
ci: replace pull_request trigger with workflow_dispatch

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,7 +1,7 @@
 name: Deploy to GitHub Pages
 
 on:
-  pull_request:
+  workflow_dispatch:
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- Remove `pull_request` trigger from pages workflow — PR branches were deploying to GitHub Pages, overwriting the main deployment
- Add `workflow_dispatch` trigger for manual redeploys