### PR TITLE
feat: decouple worktree indicators from agent sessions

### DIFF
--- a/src/Action/Agent.purs
+++ b/src/Action/Agent.purs
@@ -273,6 +273,30 @@ handleRefreshAgentSessions = do
                   { agentSessions =
                       Map.fromFoldable entries
                   }
+    -- Fetch worktree presence independently
+    wtResult <- H.liftAff $ try do
+      resp <- fetch
+        (st.agentServer <> "/worktrees")
+        { method: GET }
+      resp.text
+    case wtResult of
+      Left _ -> pure unit
+      Right wtTxt -> case jsonParser wtTxt of
+        Left _ -> pure unit
+        Right wtJson ->
+          case toArray wtJson of
+            Nothing -> pure unit
+            Just arr ->
+              let
+                keys = arr >>= \wj ->
+                  case parseWorktreeKey wj of
+                    Nothing -> []
+                    Just k -> [ k ]
+              in
+                H.modify_ _
+                  { agentWorktrees =
+                      Set.fromFoldable keys
+                  }
 
 handleToggleSessionFilter
   :: forall o. String -> HalogenAction o
@@ -315,3 +339,14 @@ parseSession json = do
   Just $ Tuple
     (owner <> "/" <> name <> "#" <> show issue)
     state
+
+-- | Parse a worktree JSON object into a session key.
+parseWorktreeKey :: Json -> Maybe String
+parseWorktreeKey json = do
+  obj <- toObject json
+  repoJson <- hush (obj .: "repo")
+  repoObj <- toObject repoJson
+  owner <- hush (repoObj .: "owner") :: Maybe String
+  name <- hush (repoObj .: "name") :: Maybe String
+  issue <- hush (obj .: "issue") :: Maybe Int
+  Just (owner <> "/" <> name <> "#" <> show issue)

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -162,6 +162,7 @@ initialState =
   , terminalKeys: Map.empty
   , terminalUrls: Map.empty
   , agentSessions: Map.empty
+  , agentWorktrees: Set.empty
   , sessionFilters: Set.empty
   }
 

--- a/src/View/Issues.purs
+++ b/src/View/Issues.purs
@@ -199,12 +199,15 @@ renderIssueRow state isHidden (Issue i) =
       state.launchedItems
     sessionState = Map.lookup launchKey
       state.agentSessions
+    hasWorktree = Set.member launchKey
+      state.agentWorktrees
     rowClass = "repo-row"
       <>
         if hasTerminal then " terminal-active"
-        else case sessionState of
-          Just _ -> " session-active"
-          Nothing -> ""
+        else if sessionState == Just "running" then
+          " session-active"
+        else if hasWorktree then " session-active"
+        else ""
   in
     [ HH.tr
         [ HE.onClick \_ -> ToggleItem key
@@ -230,18 +233,21 @@ renderIssueRow state isHidden (Issue i) =
                           <> " "
                       )
                   ]
-                    <> case sessionState of
-                      Just _ ->
-                        [ HH.span
-                            [ HP.class_
-                                ( HH.ClassName
-                                    "worktree-badge"
-                                )
-                            , HP.title "Worktree"
-                            ]
-                            [ HH.text "\x2387 " ]
-                        ]
-                      Nothing -> []
+                    <>
+                      ( if
+                          Set.member launchKey
+                            state.agentWorktrees then
+                          [ HH.span
+                              [ HP.class_
+                                  ( HH.ClassName
+                                      "worktree-badge"
+                                  )
+                              , HP.title "Worktree"
+                              ]
+                              [ HH.text "\x2387 " ]
+                          ]
+                        else []
+                      )
                     <> case sessionState of
                       Just st | st == "running" ->
                         [ HH.span
@@ -255,7 +261,7 @@ renderIssueRow state isHidden (Issue i) =
                             [ HH.text "\x25C9 " ]
                         ]
                       _ -> []
-                    <> [ HH.text i.title ]
+                        <> [ HH.text i.title ]
                 )
             , renderLabels i.labels
             ]

--- a/src/View/Projects.purs
+++ b/src/View/Projects.purs
@@ -322,8 +322,11 @@ applySessionFilter state items =
             sess = k >>= \key ->
               Map.lookup key
                 state.agentSessions
-            hasWorktree =
-              sess /= Nothing
+            hasWorktree = case k of
+              Just key ->
+                Set.member key
+                  state.agentWorktrees
+              Nothing -> false
             isRunning = sess == Just "running"
           in
             ( not
@@ -626,12 +629,17 @@ renderItemRow state projId mSf (ProjectItem item) =
     sessionState = case itemKey of
       Just k -> Map.lookup k state.agentSessions
       Nothing -> Nothing
+    hasWorktree = case itemKey of
+      Just k ->
+        Set.member k state.agentWorktrees
+      Nothing -> false
     rowClass = "repo-row"
       <>
         if hasTerminal then " terminal-active"
-        else case sessionState of
-          Just _ -> " session-active"
-          Nothing -> ""
+        else if sessionState == Just "running" then
+          " session-active"
+        else if hasWorktree then " session-active"
+        else ""
   in
     [ HH.tr
         [ HE.onClick \_ -> ToggleItem key
@@ -733,18 +741,19 @@ renderItemRow state projId mSf (ProjectItem item) =
                             Nothing -> ""
                         )
                     ]
-                      <> case sessionState of
-                        Just _ ->
-                          [ HH.span
-                              [ HP.class_
-                                  ( HH.ClassName
-                                      "worktree-badge"
-                                  )
-                              , HP.title "Worktree"
-                              ]
-                              [ HH.text "\x2387 " ]
-                          ]
-                        Nothing -> []
+                      <>
+                        ( if hasWorktree then
+                            [ HH.span
+                                [ HP.class_
+                                    ( HH.ClassName
+                                        "worktree-badge"
+                                    )
+                                , HP.title "Worktree"
+                                ]
+                                [ HH.text "\x2387 " ]
+                            ]
+                          else []
+                        )
                       <> case sessionState of
                         Just st | st == "running" ->
                           [ HH.span

--- a/src/View/Types.purs
+++ b/src/View/Types.purs
@@ -115,5 +115,6 @@ type State =
   , terminalKeys :: Map String String
   , terminalUrls :: Map String String
   , agentSessions :: Map String String
+  , agentWorktrees :: Set String
   , sessionFilters :: Set String
   }


### PR DESCRIPTION
## Summary

- Adds `GET /worktrees` fetch alongside `GET /sessions` in `RefreshAgentSessions`
- Stores worktree presence in a separate `agentWorktrees :: Set String` state field
- Worktree badge (⎇) now reflects actual worktree existence on disk, independent of active sessions
- Running badge (◉) still requires `state == "running"` from sessions API
- Session filter ("Worktree") uses the new worktree set instead of session presence

Closes #55