### PR TITLE
Add Playwright e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/index.js
 .spago/
 node_modules/
 .psci_modules/
+test-results/

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,11 @@
               pkgs.nodejs_20
               pkgs.just
               pkgs.python3
+              pkgs.chromium
             ];
+            shellHook = ''
+              export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=${pkgs.chromium}/bin/chromium
+            '';
           };
         }
       );

--- a/justfile
+++ b/justfile
@@ -23,5 +23,11 @@ restart: bundle
     sleep 1
     npx serve dist -p 10001
 
+test: bundle
+    npx playwright test
+
+test-auth: bundle
+    GH_DASHBOARD_TOKEN=$(gh auth token) npx playwright test
+
 clean:
     rm -rf output/ dist/index.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "gh-dashboard-issue-63",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gh-dashboard-issue-63",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.58.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "gh-dashboard-issue-63",
+  "version": "1.0.0",
+  "description": "[![CI](https://github.com/lambdasistemi/gh-dashboard/actions/workflows/ci.yaml/badge.svg)](https://github.com/lambdasistemi/gh-dashboard/actions/workflows/ci.yaml)",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@playwright/test": "^1.58.2"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 30_000,
+  retries: 0,
+  use: {
+    baseURL: "http://localhost:10001",
+    headless: true,
+  },
+  webServer: {
+    command: "npx serve dist -p 10001",
+    port: 10001,
+    reuseExistingServer: true,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        browserName: "chromium",
+        launchOptions: {
+          executablePath:
+            process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH ||
+            undefined,
+        },
+      },
+    },
+  ],
+});

--- a/tests/authenticated.spec.ts
+++ b/tests/authenticated.spec.ts
@@ -1,0 +1,100 @@
+// Tests that require a valid GitHub token.
+// Set GH_DASHBOARD_TOKEN env var to run these.
+// Skipped in CI unless the secret is configured.
+
+import { test, expect } from "@playwright/test";
+
+const TOKEN = process.env.GH_DASHBOARD_TOKEN ?? "";
+
+test.describe("Dashboard (authenticated)", () => {
+  test.skip(!TOKEN, "GH_DASHBOARD_TOKEN not set");
+
+  test.beforeEach(async ({ page }) => {
+    // Inject the token into localStorage before navigating
+    await page.goto("/");
+    await page.evaluate((tok) => {
+      localStorage.setItem("gh-dashboard-token", tok);
+    }, TOKEN);
+    await page.reload();
+  });
+
+  test("shows toolbar after login", async ({ page }) => {
+    await expect(page.locator(".toolbar")).toBeVisible();
+  });
+
+  test("shows Repos and Projects tabs", async ({ page }) => {
+    await expect(
+      page.locator(".tab-btn", { hasText: "Repos" })
+    ).toBeVisible();
+    await expect(
+      page.locator(".tab-btn", { hasText: "Projects" })
+    ).toBeVisible();
+  });
+
+  test("can switch to Projects tab", async ({ page }) => {
+    const projectsBtn = page.locator(".tab-btn", {
+      hasText: "Projects",
+    });
+    await projectsBtn.click();
+    await expect(projectsBtn).toHaveClass(/active/);
+  });
+
+  test("can switch back to Repos tab", async ({ page }) => {
+    await page
+      .locator(".tab-btn", { hasText: "Projects" })
+      .click();
+    const reposBtn = page.locator(".tab-btn", {
+      hasText: "Repos",
+    });
+    await reposBtn.click();
+    await expect(reposBtn).toHaveClass(/active/);
+  });
+
+  test("theme toggle switches theme", async ({ page }) => {
+    const toggle = page.locator(".theme-toggle");
+    const body = page.locator("body");
+
+    // Get initial theme
+    const initialClass = await body.getAttribute("class");
+
+    // Click toggle
+    await toggle.click();
+
+    // Theme class should change
+    const newClass = await body.getAttribute("class");
+    expect(newClass).not.toBe(initialClass);
+  });
+
+  test("filter input works", async ({ page }) => {
+    const filter = page.locator(
+      'input[placeholder="Filter repos..."]'
+    );
+    await filter.fill("test-repo");
+    await expect(filter).toHaveValue("test-repo");
+  });
+
+  test("export button is visible", async ({ page }) => {
+    await expect(
+      page.locator('button[title="Export settings"]')
+    ).toBeVisible();
+  });
+
+  test("import button is visible", async ({ page }) => {
+    await expect(
+      page.locator('button[title="Import settings"]')
+    ).toBeVisible();
+  });
+
+  test("rate limit is displayed", async ({ page }) => {
+    // Wait for API calls to complete
+    await page.waitForTimeout(3000);
+    const rateLimit = page.locator(".rate-limit");
+    // May or may not be visible depending on timing
+    // but if visible, should contain a number
+    const count = await rateLimit.count();
+    if (count > 0) {
+      const text = await rateLimit.textContent();
+      expect(text).toMatch(/\d+\/\d+/);
+    }
+  });
+});

--- a/tests/unauthenticated.spec.ts
+++ b/tests/unauthenticated.spec.ts
@@ -1,0 +1,41 @@
+// Tests that run without a GitHub token.
+// These verify the login page UI shell works correctly.
+
+import { test, expect } from "@playwright/test";
+
+test.describe("Token form (unauthenticated)", () => {
+  test.beforeEach(async ({ page }) => {
+    // Clear any saved token so we always see the login form
+    await page.goto("/");
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+  });
+
+  test("shows login form on first visit", async ({ page }) => {
+    await expect(page.locator("h1")).toHaveText("GH Dashboard");
+    await expect(
+      page.locator('input[type="password"]')
+    ).toBeVisible();
+    await expect(page.locator("button.btn", { hasText: "Connect" })).toBeVisible();
+  });
+
+  test("shows getting started instructions", async ({ page }) => {
+    await expect(page.locator("text=Getting started")).toBeVisible();
+    await expect(
+      page.locator("text=Create a GitHub token")
+    ).toBeVisible();
+  });
+
+  test("shows error on empty token submit", async ({ page }) => {
+    await page.click("text=Connect");
+    await expect(page.locator(".error")).toHaveText(
+      "Please enter a token"
+    );
+  });
+
+  test("token input accepts text", async ({ page }) => {
+    const input = page.locator('input[type="password"]');
+    await input.fill("ghp_test123");
+    await expect(input).toHaveValue("ghp_test123");
+  });
+});


### PR DESCRIPTION
## Summary
- 4 unauthenticated tests (login form, instructions, error handling)
- 9 authenticated tests (tabs, theme, filter, export/import buttons, rate limit)
- Nix flake provides system Chromium — no browser downloads needed
- `just test` runs unauth tests, `just test-auth` runs with `gh auth token`
- Authenticated tests skip gracefully when `GH_DASHBOARD_TOKEN` is unset

Closes #63

## Test plan
- [x] `just test` — 4/4 pass
- [x] `just test-auth` — 9/9 pass
- [x] `just ci` — lint + build + bundle pass