### PR TITLE
Fix Playwright CI: switch to ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,13 +11,10 @@ concurrency:
 
 jobs:
   ci:
-    runs-on: nixos
-    env:
-      PATH: /run/current-system/sw/bin:/usr/bin:/bin
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/cachix-action@v15
+      - uses: paolino/dev-assets/setup-nix@v0.0.1
         with:
-          name: paolino
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - run: nix develop --quiet --command just ci
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - run: nix develop --quiet -c just ci

--- a/flake.nix
+++ b/flake.nix
@@ -42,11 +42,7 @@
               pkgs.nodejs_20
               pkgs.just
               pkgs.python3
-              pkgs.chromium
             ];
-            shellHook = ''
-              export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=${pkgs.chromium}/bin/chromium
-            '';
           };
         }
       );

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ format:
 lint:
     purs-tidy check src/**/*.purs
 
-ci: lint build bundle
+ci: lint build bundle test-playwright
 
 serve: bundle
     npx serve dist -p 10001
@@ -23,13 +23,14 @@ restart: bundle
     sleep 1
     npx serve dist -p 10001
 
-test-run:
-    npm install --silent
+test-playwright: bundle
+    npm install
+    npx playwright install chromium
     npx playwright test
 
-test: bundle test-run
-
 test-auth: bundle
+    npm install
+    npx playwright install chromium
     GH_DASHBOARD_TOKEN=$(gh auth token) npx playwright test
 
 clean:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,15 +16,7 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      use: {
-        browserName: "chromium",
-        launchOptions: {
-          executablePath:
-            process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH ||
-            undefined,
-          args: ["--no-sandbox", "--disable-gpu"],
-        },
-      },
+      use: { browserName: "chromium" },
     },
   ],
 });


### PR DESCRIPTION
## Summary
- Switch CI from self-hosted `nixos` to `ubuntu-latest` with `setup-nix` (matches kel-circle)
- Playwright manages its own chromium (no Nix chromium needed)
- `just ci` now includes `test-playwright` — 4 unauth tests run on every PR
- Simplify playwright.config.ts (no custom executable path)

## Test plan
- [x] Tests pass locally on ubuntu
- [ ] CI on ubuntu-latest