### PR TITLE
Run all 17 Playwright tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,3 +18,5 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix develop --quiet -c just ci
+        env:
+          GH_DASHBOARD_TOKEN: ${{ secrets.GH_DASHBOARD_TOKEN }}


### PR DESCRIPTION
## Summary
- Add GH_DASHBOARD_TOKEN secret to CI workflow
- All 17 Playwright tests now run (4 unauth + 9 auth + 4 caching)
- Previously 13 were skipped due to missing token

## Test plan
- [x] Secret `GH_DASHBOARD_TOKEN` added to repo
- [ ] CI runs all 17 tests