### PR TITLE
Add toast notifications for agent events

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -193,6 +193,16 @@
     .empty-msg { color: var(--text-dim); font-size: 13px; font-style: italic; }
     @keyframes pulse { 50% { opacity: 0.6; } }
     .loading { animation: pulse 1.5s ease-in-out infinite; }
+    .toast-container { position: fixed; bottom: 16px; right: 16px; z-index: 1000; display: flex; flex-direction: column; gap: 8px; max-width: 360px; }
+    .toast { display: flex; align-items: center; gap: 8px; padding: 10px 14px; border-radius: 6px; font-size: 13px; box-shadow: 0 4px 12px rgba(0,0,0,0.3); animation: toast-in 0.3s ease-out; }
+    .toast-info { background: #1b5e20; color: #a5d6a7; }
+    body.light-theme .toast-info { background: #e8f5e9; color: #2e7d32; }
+    .toast-error { background: #b71c1c; color: #ef9a9a; }
+    body.light-theme .toast-error { background: #ffebee; color: #c62828; }
+    .toast-msg { flex: 1; }
+    .toast-close { background: none; border: none; color: inherit; opacity: 0.6; cursor: pointer; font-size: 14px; padding: 0 2px; }
+    .toast-close:hover { opacity: 1; }
+    @keyframes toast-in { from { transform: translateX(100%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
     .tab-bar { display: flex; gap: 0; }
     .tab-btn { padding: 6px 14px; border: 1px solid var(--bg-elevated); border-radius: 6px 6px 0 0; background: var(--bg-elevated); color: var(--text-muted); font-size: 13px; cursor: pointer; border-bottom: none; }
     .tab-btn:hover { color: var(--text); }

--- a/src/Action/Agent.purs
+++ b/src/Action/Agent.purs
@@ -76,7 +76,7 @@ import FFI.Terminal (attachTerminal, destroyTerminal)
 import Fetch (fetch)
 import Halogen as H
 import Storage (saveAgentServer)
-import View.Types (Action(..), State)
+import View.Types (Action(..), State, ToastLevel(..))
 
 handleLaunchAgent
   :: forall o
@@ -127,10 +127,18 @@ handleLaunchAgent dispatch toggleKey fullName issueNum = do
         }
       resp.text
     case result of
-      Left err ->
+      Left err -> do
         H.modify_ _
           { error = Just (message err) }
+        dispatch
+          ( ShowToast ("Agent error: " <> message err)
+              ToastError
+          )
       Right _ -> do
+        dispatch
+          ( ShowToast "Agent session launched"
+              ToastInfo
+          )
         let
           wsProto =
             if
@@ -174,10 +182,11 @@ handleLaunchAgent dispatch toggleKey fullName issueNum = do
 
 handleDetachAgent
   :: forall o
-   . String
+   . Dispatch o
+  -> String
   -> Int
   -> HalogenAction o
-handleDetachAgent fullName issueNum = do
+handleDetachAgent dispatch fullName issueNum = do
   let
     itemKey = fullName <> "#"
       <> show issueNum
@@ -189,6 +198,8 @@ handleDetachAgent fullName issueNum = do
     , terminalUrls =
         Map.delete itemKey s.terminalUrls
     }
+  dispatch
+    (ShowToast "Agent detached" ToastInfo)
 
 handleStopAgent
   :: forall o
@@ -233,10 +244,16 @@ handleStopAgent dispatch fullName issueNum = do
           }
         resp.text
       case result of
-        Left err ->
+        Left err -> do
           H.modify_ _
             { error = Just (message err) }
-        Right _ -> pure unit
+          dispatch
+            ( ShowToast ("Stop failed: " <> message err)
+                ToastError
+            )
+        Right _ ->
+          dispatch
+            (ShowToast "Agent stopped" ToastInfo)
       dispatch RefreshAgentSessions
 
 handleSetAgentServer

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -69,12 +69,12 @@ import Action.Repos
   , handleWorkflowNextSha
   , handleWorkflowPrevSha
   )
-import Data.Array (null)
+import Data.Array (null, filter)
 import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.Set as Set
 import Effect (Effect)
-import Effect.Aff (Aff)
+import Effect.Aff (Aff, Milliseconds(..), delay)
 import Effect.Class (liftEffect)
 import FFI.Cache as FFI.Cache
 import FFI.Clipboard (copyToClipboard)
@@ -164,6 +164,8 @@ initialState =
   , agentSessions: Map.empty
   , agentWorktrees: Set.empty
   , sessionFilters: Set.empty
+  , toasts: []
+  , nextToastId: 0
   }
 
 render :: forall m. State -> H.ComponentHTML Action () m
@@ -426,7 +428,7 @@ handleAction = case _ of
     handleLaunchAgent handleAction
       toggleKey fullName issueNum
   DetachAgent fullName issueNum ->
-    handleDetachAgent fullName issueNum
+    handleDetachAgent handleAction fullName issueNum
   StopAgent fullName issueNum ->
     handleStopAgent handleAction
       fullName issueNum
@@ -436,3 +438,29 @@ handleAction = case _ of
     handleRefreshAgentSessions
   ToggleSessionFilter label ->
     handleToggleSessionFilter label
+
+  ------------------------------------------------
+  -- Toast notifications
+  ------------------------------------------------
+
+  ShowToast msg level -> do
+    st <- H.get
+    let
+      tid = st.nextToastId
+      toast = { id: tid, message: msg, level }
+    H.modify_ _
+      { toasts = st.toasts <> [ toast ]
+      , nextToastId = tid + 1
+      }
+    -- Auto-dismiss after 4 seconds
+    H.liftAff $ delay (Milliseconds 4000.0)
+    H.modify_ \s -> s
+      { toasts = filter
+          (\t -> t.id /= tid) s.toasts
+      }
+
+  DismissToast tid ->
+    H.modify_ \s -> s
+      { toasts = filter
+          (\t -> t.id /= tid) s.toasts
+      }

--- a/src/View.purs
+++ b/src/View.purs
@@ -16,7 +16,7 @@ import Halogen.HTML.Properties as HP
 import Types (Page(..), Repo)
 import View.Projects (renderProjects)
 import View.RepoTable (renderRepoTable)
-import View.Types (Action(..), State)
+import View.Types (Action(..), State, Toast, ToastLevel(..))
 
 -- | Token input form shown when no token is set.
 renderTokenForm
@@ -95,7 +95,8 @@ renderDashboard
   -> HH.HTML w Action
 renderDashboard state repos =
   HH.div_
-    [ renderToolbar state
+    [ renderToasts state.toasts
+    , renderToolbar state
     , case state.error of
         Just err ->
           HH.div
@@ -269,6 +270,38 @@ renderToolbar state =
 activeIf :: Boolean -> String
 activeIf true = " active"
 activeIf false = ""
+
+-- | Toast notification container (bottom-right).
+renderToasts
+  :: forall w. Array Toast -> HH.HTML w Action
+renderToasts toasts =
+  HH.div
+    [ HP.class_ (HH.ClassName "toast-container") ]
+    (map renderToast toasts)
+
+-- | A single toast notification with dismiss button.
+renderToast
+  :: forall w. Toast -> HH.HTML w Action
+renderToast t =
+  HH.div
+    [ HP.class_
+        ( HH.ClassName
+            ( "toast toast-"
+                <> case t.level of
+                  ToastInfo -> "info"
+                  ToastError -> "error"
+            )
+        )
+    ]
+    [ HH.span
+        [ HP.class_ (HH.ClassName "toast-msg") ]
+        [ HH.text t.message ]
+    , HH.button
+        [ HE.onClick \_ -> DismissToast t.id
+        , HP.class_ (HH.ClassName "toast-close")
+        ]
+        [ HH.text "\x2715" ]
+    ]
 
 -- | Rate limit display.
 renderRateLimit

--- a/src/View/Types.purs
+++ b/src/View/Types.purs
@@ -2,6 +2,8 @@
 module View.Types
   ( Action(..)
   , State
+  , Toast
+  , ToastLevel(..)
   ) where
 
 import Data.Maybe (Maybe)
@@ -16,6 +18,16 @@ import Types
   , RepoDetail
   , StatusField
   )
+
+-- | Toast notification severity.
+data ToastLevel = ToastInfo | ToastError
+
+-- | A toast notification with auto-dismiss.
+type Toast =
+  { id :: Int
+  , message :: String
+  , level :: ToastLevel
+  }
 
 -- | Actions emitted by the view.
 data Action
@@ -70,6 +82,8 @@ data Action
   | SetAgentServer String
   | RefreshAgentSessions
   | ToggleSessionFilter String
+  | ShowToast String ToastLevel
+  | DismissToast Int
 
 -- | Application state (referenced by view).
 type State =
@@ -117,4 +131,6 @@ type State =
   , agentSessions :: Map String String
   , agentWorktrees :: Set String
   , sessionFilters :: Set String
+  , toasts :: Array Toast
+  , nextToastId :: Int
   }


### PR DESCRIPTION
## Summary
- Toast container in bottom-right with slide-in animation
- Auto-dismiss after 4 seconds, manual X dismiss
- Agent launched/detached/stopped → info toast (green)
- Agent errors → error toast (red)
- Dark + light theme support

Closes #44

## Test plan
- [x] Lint + build + bundle pass