### PR TITLE
Publish NAVIGATION.md on GitHub Pages with MkDocs

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -28,6 +28,7 @@ jobs:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - run: nix develop --quiet --command just bundle
+      - run: nix develop --quiet --command just build-docs
       - uses: actions/upload-pages-artifact@v3
         with:
           path: dist

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/index.js
 node_modules/
 .psci_modules/
 test-results/
+site/

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+../NAVIGATION.md

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,28 @@
 {
   "nodes": {
+    "dev-assets-mkdocs": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "dir": "mkdocs",
+        "lastModified": 1773483673,
+        "narHash": "sha256-vUG5w8RAR0uycBosoxQ0sRs3pc4hXu64peXPfFXHLaY=",
+        "owner": "paolino",
+        "repo": "dev-assets",
+        "rev": "0e54367faea344db560178d7d79edb2db9cd379c",
+        "type": "github"
+      },
+      "original": {
+        "dir": "mkdocs",
+        "owner": "paolino",
+        "repo": "dev-assets",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -16,6 +39,24 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1763759067,
+        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1770169770,
@@ -29,6 +70,21 @@
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1761765539,
+        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
         "type": "github"
       }
     },
@@ -55,6 +111,7 @@
     },
     "root": {
       "inputs": {
+        "dev-assets-mkdocs": "dev-assets-mkdocs",
         "nixpkgs": "nixpkgs",
         "purescript-overlay": "purescript-overlay"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,12 +5,17 @@
       url = "github:thomashoneyman/purescript-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    dev-assets-mkdocs = {
+      url = "github:paolino/dev-assets?dir=mkdocs";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
     {
       nixpkgs,
       purescript-overlay,
+      dev-assets-mkdocs,
       ...
     }:
     let
@@ -33,6 +38,9 @@
         in
         {
           default = pkgs.mkShell {
+            inputsFrom = [
+              dev-assets-mkdocs.devShells.${system}.default
+            ];
             buildInputs = [
               pkgs.purs
               pkgs.spago-unstable

--- a/justfile
+++ b/justfile
@@ -31,5 +31,17 @@ test-auth: bundle
     npm install --silent
     GH_DASHBOARD_TOKEN=$(gh auth token) npx playwright test
 
+build-docs:
+    mkdocs build --strict
+
+serve-docs:
+    mkdocs serve
+
+deploy-docs:
+    mkdocs gh-deploy --force
+
+# Include docs build in CI for validation
+ci-docs: build-docs
+
 clean:
-    rm -rf output/ dist/index.js
+    rm -rf output/ dist/index.js site/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,34 @@
+site_name: GH Dashboard
+site_url: https://lambdasistemi.github.io/gh-dashboard/docs/
+repo_url: https://github.com/lambdasistemi/gh-dashboard
+repo_name: lambdasistemi/gh-dashboard
+
+theme:
+  name: material
+  palette:
+    - scheme: slate
+      primary: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to light mode
+    - scheme: default
+      primary: blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to dark mode
+
+nav:
+  - Navigation: index.md
+
+docs_dir: docs
+site_dir: dist/docs
+
+plugins:
+  - search
+
+markdown_extensions:
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight
+  - pymdownx.superfences


### PR DESCRIPTION
## Summary
- MkDocs with material theme via `paolino/dev-assets/mkdocs` flake input
- NAVIGATION.md served as docs at `/docs/` subpath alongside the app
- Pages workflow builds docs after bundle
- `just build-docs` / `serve-docs` / `deploy-docs` recipes

Docs will be at: https://lambdasistemi.github.io/gh-dashboard/docs/

Closes #66

## Test plan
- [x] `just build-docs` builds successfully
- [ ] Pages deployment serves docs at /docs/