### PR TITLE
Add docs link to toolbar

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -216,7 +216,7 @@
     @keyframes toast-in { from { transform: translateX(100%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
     .toolbar { display: flex; align-items: center; justify-content: space-between; }
     .toolbar-icons { display: flex; gap: 4px; }
-    .toolbar-icon { background: none; border: none; color: var(--text-muted); font-size: 18px; cursor: pointer; padding: 6px 8px; border-radius: 4px; }
+    .toolbar-icon { background: none; border: none; color: var(--text-muted); font-size: 18px; cursor: pointer; padding: 6px 8px; border-radius: 4px; text-decoration: none; }
     .toolbar-icon:hover { color: var(--text); background: var(--bg-elevated); }
     .toolbar-icon.active { color: var(--accent); }
     .tab-bar { display: flex; gap: 0; }

--- a/src/App/View.purs
+++ b/src/App/View.purs
@@ -188,7 +188,16 @@ renderToolbar state =
         [ HP.class_
             (HH.ClassName "toolbar-icons")
         ]
-        [ HH.button
+        [ HH.a
+            [ HP.href
+                "https://lambdasistemi.github.io/gh-dashboard/docs/"
+            , HP.target "_blank"
+            , HP.class_
+                (HH.ClassName "toolbar-icon")
+            , HP.title "Docs"
+            ]
+            [ HH.text "\x1F4D6" ]
+        , HH.button
             [ HE.onClick \_ ->
                 SwitchPage
                   ( if state.currentPage == FiltersPage then WIPPage


### PR DESCRIPTION
## Summary
- Adds a 📖 docs link icon in the toolbar-icons area, before the filter and settings buttons
- Links to the MkDocs-rendered docs at lambdasistemi.github.io/gh-dashboard/docs/

Closes #82