### PR TITLE
unsquash: PR #80 unfolded (2 commits)

### DIFF
--- a/src/FFI/Cache.js
+++ b/src/FFI/Cache.js
@@ -60,6 +60,8 @@ export function putCachedResponseImpl(url) {
             .then((db) => {
               const tx = db.transaction("responses", "readwrite");
               const store = tx.objectStore("responses");
+              const key = url.startsWith("graphql:") ? "graphql:..." : url;
+              console.log("[cache] PUT", key);
               store.put({
                 url: url,
                 etag: etag,

--- a/src/FFI/Cache.js
+++ b/src/FFI/Cache.js
@@ -37,8 +37,11 @@ export function getCachedResponseImpl(url) {
             const req = store.get(url);
             req.onsuccess = () => {
               if (req.result) {
+                const key = url.startsWith("graphql:") ? "graphql:..." : url;
+                console.log("[cache] HIT", key);
                 onFound(req.result)();
               } else {
+                console.log("[cache] MISS", url.startsWith("graphql:") ? "graphql:..." : url);
                 onMissing();
               }
             };


### PR DESCRIPTION
Original: #80 (feat: stale-while-revalidate + GraphQL caching — 1 squashed commit, 164+/12-, 6 files)

Unfolded into 2 commits. Cache.js split at function boundary.