### PR TITLE
fix: Reset all clears the Kanban project binding

### DIFF
--- a/src/App/Main.purs
+++ b/src/App/Main.purs
@@ -95,6 +95,7 @@ import App.Refresh (doRefresh, loadCachedRepos)
 import Lib.Util.Repo (applyFilter)
 import App.Storage
   ( clearAll
+  , clearKanbanProject
   , clearToken
   , loadAgentServer
   , loadKanbanProject
@@ -245,7 +246,9 @@ handleAction = case _ of
         H.modify_ _
           { token = tok, hasToken = true }
         handleAction RefreshAgentSessions
-        -- Load kanban project items if configured
+        -- Load kanban project items if configured;
+        -- otherwise fetch the project list so the
+        -- setup picker populates on Kanban pages.
         case kbProject of
           Just projId -> do
             cachedItems <- H.liftAff $
@@ -262,7 +265,8 @@ handleAction = case _ of
               Nothing -> pure unit
             handleAction
               (RefreshProjectItems projId)
-          Nothing -> pure unit
+          Nothing ->
+            handleAction RefreshProjects
         case vs.currentPage of
           BacklogPage -> pure unit
           WIPPage -> pure unit
@@ -325,6 +329,11 @@ handleAction = case _ of
         , loading = true
         }
       doRefresh st.token
+      -- Always fetch projects so the Kanban picker
+      -- populates even if the user lands straight
+      -- on a Kanban column without a selected project.
+      when (st.kanbanProject == Nothing) do
+        handleAction RefreshProjects
 
   ------------------------------------------------
   -- Repo actions (delegated)
@@ -455,6 +464,11 @@ handleAction = case _ of
         , currentPage = ReposPage
         , expandedProject = Nothing
         , projectItems = Map.empty
+        , kanbanProject = Nothing
+        , agentServer = ""
+        , projectStatusFields = Map.empty
+        , kanbanLabelFilters = Set.empty
+        , projectRepoFilters = Set.empty
         }
 
   SwitchPage page -> do
@@ -462,10 +476,17 @@ handleAction = case _ of
     persistView
     handleAction RefreshAgentSessions
     st <- H.get
+    let
+      ensureProjectsLoaded =
+        when
+          ( st.kanbanProject == Nothing
+              && null st.projects
+          )
+          (handleAction RefreshProjects)
     case page of
-      BacklogPage -> pure unit
-      WIPPage -> pure unit
-      DonePage -> pure unit
+      BacklogPage -> ensureProjectsLoaded
+      WIPPage -> ensureProjectsLoaded
+      DonePage -> ensureProjectsLoaded
       FiltersPage -> pure unit
       SettingsPage -> pure unit
       ProjectsPage ->
@@ -537,6 +558,16 @@ handleAction = case _ of
     H.modify_ _ { kanbanProject = Just projId }
     liftEffect $ saveKanbanProject projId
     handleAction (RefreshProjectItems projId)
+  ClearKanbanProject -> do
+    liftEffect clearKanbanProject
+    H.modify_ _
+      { kanbanProject = Nothing
+      , projectItems = Map.empty
+      , projectStatusFields = Map.empty
+      , kanbanLabelFilters = Set.empty
+      , projectRepoFilters = Set.empty
+      }
+    handleAction RefreshProjects
   CreateKanbanProject -> do
     st <- H.get
     result <- H.liftAff $

--- a/src/App/Main.purs
+++ b/src/App/Main.purs
@@ -162,6 +162,7 @@ initialState =
   , expandedProject: Nothing
   , projectItems: Map.empty
   , projectItemsLoading: false
+  , projectsChecking: Set.empty
   , projectRepoFilters: Set.empty
   , projectStatusFields: Map.empty
   , newItemTitle: ""
@@ -568,6 +569,16 @@ handleAction = case _ of
       , projectRepoFilters = Set.empty
       }
     handleAction RefreshProjects
+  CheckProjectCompat projId -> do
+    H.modify_ \s -> s
+      { projectsChecking =
+          Set.insert projId s.projectsChecking
+      }
+    handleAction (RefreshProjectItems projId)
+    H.modify_ \s -> s
+      { projectsChecking =
+          Set.delete projId s.projectsChecking
+      }
   CreateKanbanProject -> do
     st <- H.get
     result <- H.liftAff $

--- a/src/App/Storage.purs
+++ b/src/App/Storage.purs
@@ -12,6 +12,7 @@ module App.Storage
   , saveAgentServer
   , loadKanbanProject
   , saveKanbanProject
+  , clearKanbanProject
   , clearToken
   , clearAll
   ) where
@@ -303,6 +304,12 @@ saveKanbanProject pid = do
   s <- localStorage w
   Storage.setItem storageKeyKanbanProject pid s
 
+clearKanbanProject :: Effect Unit
+clearKanbanProject = do
+  w <- window
+  s <- localStorage w
+  Storage.removeItem storageKeyKanbanProject s
+
 storageKeyCryptoKey :: String
 storageKeyCryptoKey = "gh-dashboard-crypto-key"
 
@@ -320,3 +327,5 @@ clearAll = do
   Storage.removeItem storageKeyRepos s
   Storage.removeItem storageKeyView s
   Storage.removeItem storageKeyCryptoKey s
+  Storage.removeItem storageKeyKanbanProject s
+  Storage.removeItem storageKeyAgentServer s

--- a/src/App/View.purs
+++ b/src/App/View.purs
@@ -7,14 +7,14 @@ module App.View
 
 import Prelude
 
-import Data.Array (null)
+import Data.Array (find, null)
 import Data.Show (show)
 import Data.Maybe (Maybe(..))
 import Lib.GitHub (RateLimit)
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
-import Lib.Types (Page(..), Repo)
+import Lib.Types (Page(..), Project(..), Repo)
 import App.View.Kanban (columnCount, renderFilters, renderKanban)
 import Lib.UI.Widgets (settingsRow)
 import App.View.Projects (renderProjects)
@@ -240,6 +240,10 @@ renderSettings state =
             (HH.ClassName "detail-heading")
         ]
         [ HH.text "Settings" ]
+    -- Kanban project
+    , settingsRow "Kanban project"
+        "The GitHub Projects v2 board shown in the Backlog/WIP/Done columns"
+        (renderKanbanProjectSetting state)
     -- Agent server
     , settingsRow "Agent"
         "URL of the agent daemon that manages sessions and worktrees"
@@ -305,6 +309,39 @@ renderSettings state =
             [ HH.text "Source code" ]
         ]
     ]
+
+-- | Current Kanban project display + "Change project" action.
+renderKanbanProjectSetting
+  :: forall w. State -> Array (HH.HTML w Action)
+renderKanbanProjectSetting state =
+  case state.kanbanProject of
+    Nothing ->
+      [ HH.span
+          [ HP.class_ (HH.ClassName "muted") ]
+          [ HH.text "No project selected" ]
+      ]
+    Just pid ->
+      let
+        title =
+          case
+            find
+              (\(Project p) -> p.id == pid)
+              state.projects
+            of
+            Just (Project p) -> p.title
+            Nothing -> pid
+      in
+        [ HH.span
+            [ HP.class_
+                (HH.ClassName "kanban-project-title")
+            ]
+            [ HH.text title ]
+        , HH.button
+            [ HE.onClick \_ -> ClearKanbanProject
+            , HP.class_ (HH.ClassName "btn-small")
+            ]
+            [ HH.text "Change project" ]
+        ]
 
 -- | Page indicator dots for mobile swipe nav.
 renderPageIndicator

--- a/src/App/View.purs
+++ b/src/App/View.purs
@@ -12,6 +12,7 @@ import Data.Show (show)
 import Data.Maybe (Maybe(..))
 import Lib.GitHub (RateLimit)
 import Halogen.HTML as HH
+import Halogen.HTML.Core (AttrName(..))
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Lib.Types (Page(..), Project(..), Repo)
@@ -43,6 +44,12 @@ renderTokenForm state =
             , HP.value state.token
             , HE.onValueInput SetToken
             , HP.class_ (HH.ClassName "input")
+            , HP.attr (AttrName "autocomplete") "off"
+            , HP.attr (AttrName "data-1p-ignore") "true"
+            , HP.attr (AttrName "data-lpignore") "true"
+            , HP.attr (AttrName "data-bwignore") "true"
+            , HP.attr (AttrName "data-form-type") "other"
+            , HP.name "gh-token"
             ]
         , HH.button
             [ HE.onClick \_ -> SubmitToken

--- a/src/App/View/Kanban.purs
+++ b/src/App/View/Kanban.purs
@@ -96,19 +96,40 @@ renderProjectSetup
 renderProjectSetup state =
   HH.div
     [ HP.class_ (HH.ClassName "kanban-setup") ]
-    [ HH.h2_ [ HH.text "Select a project" ]
+    [ HH.h2_ [ HH.text "Pick a Kanban project" ]
     , HH.p
         [ HP.class_ (HH.ClassName "muted") ]
         [ HH.text
-            "The project must have exactly three statuses: Backlog, WIP, Done."
+            "This dashboard shows one GitHub Projects v2 board as a Backlog / WIP / Done Kanban. The project must have a Status field with those three options."
+        ]
+    , HH.ol
+        [ HP.class_ (HH.ClassName "muted")
+        , HP.style "padding-left:1.2em; margin:0 0 12px"
+        ]
+        [ HH.li_
+            [ HH.text
+                "Click "
+            , HH.strong_ [ HH.text "Check" ]
+            , HH.text
+                " on a project to verify it has Backlog/WIP/Done."
+            ]
+        , HH.li_
+            [ HH.text "If it's compatible, click "
+            , HH.strong_ [ HH.text "Use this" ]
+            , HH.text " to bind it."
+            ]
+        , HH.li_
+            [ HH.text
+                "No compatible project? Create one below."
+            ]
         ]
     , if state.projectsLoading then
-        HH.p_ [ HH.text "Loading projects..." ]
+        HH.p_ [ HH.text "Loading projects\x2026" ]
       else if null state.projects then
         HH.div_
           [ HH.p
               [ HP.class_ (HH.ClassName "muted") ]
-              [ HH.text "No projects found." ]
+              [ HH.text "No projects found for this token." ]
           , refreshButton RefreshProjects
           ]
       else
@@ -122,15 +143,20 @@ renderProjectSetup state =
                   state.projects
               )
           , HH.div
+              [ HP.style "margin-top:8px" ]
+              [ refreshButton RefreshProjects ]
+          , HH.div
               [ HP.class_
                   (HH.ClassName "kanban-create")
+              , HP.style
+                  "margin-top:20px; padding-top:12px; border-top:1px solid var(--border)"
               ]
               [ HH.p
                   [ HP.class_
                       (HH.ClassName "muted")
                   ]
                   [ HH.text
-                      "Or create a new project:"
+                      "None of these work? Create a new one:"
                   ]
               , HH.button
                   [ HE.onClick \_ ->
@@ -146,7 +172,10 @@ renderProjectSetup state =
                       (HH.ClassName "muted")
                   ]
                   [ HH.text
-                      "After creation, rename the default statuses to Backlog, WIP, Done in GitHub."
+                      "After creation, rename the default statuses to Backlog, WIP, Done in GitHub, then click "
+                  , HH.strong_
+                      [ HH.text "Check" ]
+                  , HH.text " here."
                   ]
               ]
           ]
@@ -160,13 +189,62 @@ renderProjectOption
   -> HH.HTML w Action
 renderProjectOption state (Project p) =
   let
-    mSf = Map.lookup p.id
-      state.projectStatusFields
+    mSf = Map.lookup p.id state.projectStatusFields
     valid = case mSf of
       Just sf -> hasRequiredStatuses sf
       Nothing -> false
     loaded = Map.member p.id
       state.projectStatusFields
+    checking = Set.member p.id
+      state.projectsChecking
+    statusBadge =
+      if checking then
+        HH.span
+          [ HP.class_ (HH.ClassName "muted") ]
+          [ HH.text "Checking\x2026" ]
+      else if not loaded then
+        HH.span
+          [ HP.class_ (HH.ClassName "muted") ]
+          [ HH.text "Not checked yet" ]
+      else if valid then
+        HH.span
+          [ HP.class_ (HH.ClassName "badge")
+          , HP.style "color:var(--ok,#3fb950)"
+          ]
+          [ HH.text "\x2713 Compatible" ]
+      else
+        HH.span
+          [ HP.class_ (HH.ClassName "error") ]
+          [ HH.text
+              "\x2717 Needs Backlog/WIP/Done statuses"
+          ]
+    actionBtn =
+      if checking then
+        HH.button
+          [ HP.disabled true
+          , HP.class_ (HH.ClassName "btn-small")
+          ]
+          [ HH.text "Checking\x2026" ]
+      else if valid then
+        HH.button
+          [ HE.onClick \_ -> SetKanbanProject p.id
+          , HP.class_ (HH.ClassName "btn")
+          ]
+          [ HH.text "Use this" ]
+      else if loaded then
+        HH.button
+          [ HP.disabled true
+          , HP.class_ (HH.ClassName "btn-small")
+          , HP.title
+              "Rename the Status options on GitHub to Backlog, WIP, Done, then check again"
+          ]
+          [ HH.text "Not compatible" ]
+      else
+        HH.button
+          [ HE.onClick \_ -> CheckProjectCompat p.id
+          , HP.class_ (HH.ClassName "btn-small")
+          ]
+          [ HH.text "Check" ]
   in
     HH.div
       [ HP.class_
@@ -177,42 +255,26 @@ renderProjectOption state (Project p) =
                     else ""
               )
           )
-      , if valid then
-          HE.onClick \_ -> SetKanbanProject p.id
-        else
-          HE.onClick \_ ->
-            RefreshProjectItems p.id
+      , HP.style
+          "display:flex; align-items:center; gap:10px; padding:8px 10px; border:1px solid var(--border); border-radius:4px; margin-bottom:6px"
       ]
-      [ HH.span
-          [ HP.class_
-              (HH.ClassName "kanban-project-title")
+      [ HH.div
+          [ HP.style "flex:1; min-width:0" ]
+          [ HH.div
+              [ HP.class_
+                  (HH.ClassName "kanban-project-title")
+              , HP.style "font-weight:500"
+              ]
+              [ HH.text p.title ]
+          , HH.div
+              [ HP.style
+                  "font-size:11px; color:var(--text-dim); margin-top:2px"
+              ]
+              [ HH.text (show p.itemCount <> " items \x00B7 ")
+              , statusBadge
+              ]
           ]
-          [ HH.text p.title ]
-      , HH.span
-          [ HP.class_
-              (HH.ClassName "kanban-project-count")
-          ]
-          [ HH.text
-              (show p.itemCount <> " items")
-          ]
-      , if not loaded then
-          HH.span
-            [ HP.class_ (HH.ClassName "muted") ]
-            [ HH.text " (click to check)" ]
-        else if valid then
-          HH.span
-            [ HP.class_
-                (HH.ClassName "badge")
-            ]
-            [ HH.text " \x2713" ]
-        else
-          HH.span
-            [ HP.class_
-                (HH.ClassName "error")
-            ]
-            [ HH.text
-                " Missing Backlog/WIP/Done statuses"
-            ]
+      , actionBtn
       ]
 
 -- | Filters pane — repo and label selectors.

--- a/src/App/View/Types.purs
+++ b/src/App/View/Types.purs
@@ -81,6 +81,7 @@ data Action
   | SubmitRenameProject String String
   | ToggleKanbanLabelFilter String
   | SetKanbanProject String
+  | ClearKanbanProject
   | CreateKanbanProject
   | LaunchAgent String String Int
   | DetachAgent String Int

--- a/src/App/View/Types.purs
+++ b/src/App/View/Types.purs
@@ -82,6 +82,7 @@ data Action
   | ToggleKanbanLabelFilter String
   | SetKanbanProject String
   | ClearKanbanProject
+  | CheckProjectCompat String
   | CreateKanbanProject
   | LaunchAgent String String Int
   | DetachAgent String Int
@@ -126,6 +127,7 @@ type State =
   , expandedProject :: Maybe String
   , projectItems :: Map String (Array ProjectItem)
   , projectItemsLoading :: Boolean
+  , projectsChecking :: Set String
   , projectRepoFilters :: Set String
   , projectStatusFields :: Map String StatusField
   , newItemTitle :: String


### PR DESCRIPTION
## Summary
- \`clearAll\` now also removes \`gh-dashboard-kanban-project\` and \`gh-dashboard-agent-server\` from localStorage, and \`ResetAll\` resets the corresponding state fields. Previously, Reset All left the project binding in place, so pasting a new token landed on an empty Kanban with no way to change it.
- Settings shows the current Kanban project (by title) with a **Change project** button that clears the binding and re-fetches the project list — no DevTools needed.
- \`Initialize\` / \`SubmitToken\` / \`SwitchPage\` auto-fetch the project list when no project is selected, so the setup picker appears without a manual refresh.

## Test plan
- [ ] With a project selected, open Settings — project title is shown.
- [ ] Click **Change project** — picker appears, items stop rendering, localStorage key \`gh-dashboard-kanban-project\` is removed.
- [ ] **Reset all** → re-enter token → Kanban setup picker appears with the project list populated.
- [ ] Paste a token whose account has no project yet — picker shows "No projects found" plus the **Create Kanban project** button.