### PR TITLE
feat: dependency edges (native + task-list + body-scrape)

### DIFF
--- a/src/App/View/Projects.purs
+++ b/src/App/View/Projects.purs
@@ -19,7 +19,14 @@ import Halogen.HTML as HH
 import Halogen.HTML.Core (AttrName(..))
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
-import Lib.Types (Project(..), ProjectItem(..), StatusField)
+import Lib.Types
+  ( Edge(..)
+  , EdgeKind(..)
+  , EdgeSource(..)
+  , Project(..)
+  , ProjectItem(..)
+  , StatusField
+  )
 import App.View.Widgets
   ( copyButton
   , launchButton
@@ -926,9 +933,107 @@ renderItemRow state projId mSf (ProjectItem item) =
                         )
                     ]
                 ]
+            edgesRows = renderEdges item.edges
           in
-            controls <> labels <> body
+            controls <> labels <> edgesRows <> body
         else []
+
+-- | Render grouped dependency edges (blocked by /
+-- | blocking / tracks / tracked in) as table rows under
+-- | an expanded item.
+renderEdges
+  :: forall w
+   . Array Edge
+  -> Array (HH.HTML w Action)
+renderEdges edges =
+  if null edges then []
+  else
+    let
+      group kind =
+        filter (\(Edge e) -> e.kind == kind) edges
+      section label kind =
+        let
+          es = group kind
+        in
+          if null es then []
+          else [ renderEdgeGroup label es ]
+    in
+      [ HH.tr
+          [ HP.class_ (HH.ClassName "detail-row") ]
+          [ HH.td
+              [ HP.colSpan 3
+              , HP.style
+                  "padding:6px 10px; font-size:12px"
+              ]
+              ( section "Blocked by" EdgeBlockedBy
+                  <> section "Blocking" EdgeBlocking
+                  <> section "Tracks" EdgeTracks
+                  <> section "Tracked in" EdgeTrackedIn
+              )
+          ]
+      ]
+
+renderEdgeGroup
+  :: forall w
+   . String
+  -> Array Edge
+  -> HH.HTML w Action
+renderEdgeGroup label edges =
+  HH.div
+    [ HP.style "margin:2px 0" ]
+    [ HH.span
+        [ HP.style
+            "color:var(--text-dim); margin-right:6px"
+        ]
+        [ HH.text (label <> ":") ]
+    , HH.span_
+        ( Array.intersperse
+            ( HH.span
+                [ HP.style
+                    "color:var(--text-dim); margin:0 4px"
+                ]
+                [ HH.text "\x00B7" ]
+            )
+            (map renderEdgeRef edges)
+        )
+    ]
+
+renderEdgeRef
+  :: forall w
+   . Edge
+  -> HH.HTML w Action
+renderEdgeRef (Edge e) =
+  let
+    label = e.repo <> "#" <> show e.number
+    titleAttr = case e.title of
+      Just t -> t <> " \x00B7 " <> sourceTag e.source
+      Nothing -> sourceTag e.source
+    sourceBadge = HH.span
+      [ HP.style
+          "font-size:10px; color:var(--text-dim); margin-left:4px"
+      ]
+      [ HH.text ("[" <> sourceTag e.source <> "]") ]
+  in
+    case e.url of
+      Just u ->
+        HH.span_
+          [ HH.a
+              [ HP.href u
+              , HP.target "_blank"
+              , HP.title titleAttr
+              ]
+              [ HH.text label ]
+          , sourceBadge
+          ]
+      Nothing ->
+        HH.span
+          [ HP.title titleAttr ]
+          [ HH.text label, sourceBadge ]
+
+sourceTag :: EdgeSource -> String
+sourceTag SourceNative = "native"
+sourceTag SourceTaskList = "tasklist"
+sourceTag SourceBody = "body"
 
 -- | Previous column in the Kanban flow.
 prevCol :: String -> String

--- a/src/App/View/Projects.purs
+++ b/src/App/View/Projects.purs
@@ -946,32 +946,47 @@ renderEdges
    . Array Edge
   -> Array (HH.HTML w Action)
 renderEdges edges =
-  if null edges then []
-  else
-    let
-      group kind =
-        filter (\(Edge e) -> e.kind == kind) edges
-      section label kind =
-        let
-          es = group kind
-        in
-          if null es then []
-          else [ renderEdgeGroup label es ]
-    in
-      [ HH.tr
-          [ HP.class_ (HH.ClassName "detail-row") ]
-          [ HH.td
-              [ HP.colSpan 3
-              , HP.style
-                  "padding:6px 10px; font-size:12px"
-              ]
-              ( section "Blocked by" EdgeBlockedBy
-                  <> section "Blocking" EdgeBlocking
-                  <> section "Tracks" EdgeTracks
-                  <> section "Tracked in" EdgeTrackedIn
-              )
-          ]
-      ]
+  let
+    group kind =
+      filter (\(Edge e) -> e.kind == kind) edges
+    section label kind =
+      let
+        es = group kind
+      in
+        if null es then []
+        else [ renderEdgeGroup label es ]
+    heading =
+      HH.div
+        [ HP.style
+            "color:var(--text-dim); font-size:11px; text-transform:uppercase; letter-spacing:0.5px; margin:0 0 4px"
+        ]
+        [ HH.text "Dependencies" ]
+    empty =
+      HH.div
+        [ HP.style
+            "color:var(--text-dim); font-style:italic"
+        ]
+        [ HH.text
+            "No dependencies detected. Add a native \"Blocked by\" link on GitHub, a task-list entry, or a \"blocked by owner/repo#N\" line in the body."
+        ]
+    inner =
+      if null edges then [ empty ]
+      else
+        section "Blocked by" EdgeBlockedBy
+          <> section "Blocking" EdgeBlocking
+          <> section "Tracks" EdgeTracks
+          <> section "Tracked in" EdgeTrackedIn
+  in
+    [ HH.tr
+        [ HP.class_ (HH.ClassName "detail-row") ]
+        [ HH.td
+            [ HP.colSpan 3
+            , HP.style
+                "padding:8px 10px; font-size:12px; border-top:1px dashed var(--border)"
+            ]
+            ([ heading ] <> inner)
+        ]
+    ]
 
 renderEdgeGroup
   :: forall w

--- a/src/Lib/FFI/EdgeRegex.js
+++ b/src/Lib/FFI/EdgeRegex.js
@@ -1,0 +1,22 @@
+const BLOCKED_BY =
+  /(?:blocked\s+by|depends\s+on|requires|needs|prereq(?:uisite)?|waits\s+on)\s+([\w.-]+\/[\w.-]+)?#(\d+)/gi;
+const BLOCKING =
+  /(?:blocks|unblocks|prerequisite\s+of)\s+([\w.-]+\/[\w.-]+)?#(\d+)/gi;
+
+const collect = (re, kind, body, out) => {
+  re.lastIndex = 0;
+  let m;
+  while ((m = re.exec(body)) !== null) {
+    const n = parseInt(m[2], 10);
+    if (!Number.isFinite(n)) continue;
+    out.push({ kind, repo: m[1] || "", number: n });
+  }
+};
+
+export const scanEdges = (body) => {
+  if (typeof body !== "string" || body.length === 0) return [];
+  const out = [];
+  collect(BLOCKED_BY, "blockedBy", body, out);
+  collect(BLOCKING, "blocking", body, out);
+  return out;
+};

--- a/src/Lib/FFI/EdgeRegex.purs
+++ b/src/Lib/FFI/EdgeRegex.purs
@@ -1,0 +1,18 @@
+-- | FFI helper: scan an issue body for dependency
+-- | references anchored by keywords like "blocked by"
+-- | or "blocks".
+module Lib.FFI.EdgeRegex
+  ( ScanHit
+  , scanEdges
+  ) where
+
+-- | Single hit: kind ("blockedBy" or "blocking"), optional
+-- | repo ("" if the reference omitted the `owner/repo`
+-- | prefix), and issue number.
+type ScanHit =
+  { kind :: String
+  , repo :: String
+  , number :: Int
+  }
+
+foreign import scanEdges :: String -> Array ScanHit

--- a/src/Lib/GitHub/GraphQL.purs
+++ b/src/Lib/GitHub/GraphQL.purs
@@ -53,7 +53,7 @@ import Data.Array (catMaybes, head, mapMaybe)
 import Data.Array (head) as Array
 import Data.Bifunctor (lmap)
 import Data.Either (Either(..), hush)
-import Data.Maybe (Maybe(..), isNothing)
+import Data.Maybe (Maybe(..), fromMaybe, isNothing)
 import Data.Array (intercalate)
 import Data.Traversable (traverse)
 import Data.HTTP.Method (Method(..))
@@ -62,10 +62,14 @@ import Effect.Exception (message)
 import Fetch (fetch)
 import Lib.FFI.Cache as Cache
 import Lib.Types
-  ( Project(..)
+  ( Edge(..)
+  , EdgeKind(..)
+  , EdgeSource(..)
+  , Project(..)
   , ProjectItem(..)
   , StatusField
   )
+import Lib.Util.EdgeParse (parseBodyEdges)
 
 ------------------------------------------------------------
 -- Core GraphQL transport
@@ -212,7 +216,20 @@ projectItemsQuery =
           } }
           content {
             ... on Issue { title url number body
-              repository { nameWithOwner } }
+              repository { nameWithOwner }
+              blockedBy(first: 20) { nodes {
+                number url title
+                repository { nameWithOwner } } }
+              blocking(first: 20) { nodes {
+                number url title
+                repository { nameWithOwner } } }
+              trackedIssues(first: 20) { nodes {
+                number url title
+                repository { nameWithOwner } } }
+              trackedInIssues(first: 20) { nodes {
+                number url title
+                repository { nameWithOwner } } }
+            }
             ... on PullRequest { title url number body
               repository { nameWithOwner } }
             ... on DraftIssue { id title body }
@@ -602,6 +619,34 @@ parseProjectItem json = case toObject json of
                 "Status"
                 fvNodes
               labels_ = extractLabels fvNodes
+              selfRepo = fromMaybe "" repoName_
+              nativeEdges =
+                extractEdgeConnection selfRepo
+                  SourceNative
+                  EdgeBlockedBy
+                  "blockedBy"
+                  contentJson
+                  <> extractEdgeConnection selfRepo
+                    SourceNative
+                    EdgeBlocking
+                    "blocking"
+                    contentJson
+              trackEdges =
+                extractEdgeConnection selfRepo
+                  SourceTaskList
+                  EdgeTracks
+                  "trackedIssues"
+                  contentJson
+                  <> extractEdgeConnection selfRepo
+                    SourceTaskList
+                    EdgeTrackedIn
+                    "trackedInIssues"
+                    contentJson
+              bodyEdges = case body_ of
+                Just b -> parseBodyEdges selfRepo b
+                Nothing -> []
+              edges_ =
+                nativeEdges <> trackEdges <> bodyEdges
             Right $ Just $ ProjectItem
               { itemId: itemId_
               , draftId: draftId_
@@ -613,6 +658,7 @@ parseProjectItem json = case toObject json of
               , labels: labels_
               , number: number_
               , body: body_
+              , edges: edges_
               }
 
 -- | Extract a single-select field value by name.
@@ -638,6 +684,62 @@ extractFieldValue fieldName nodes =
             Left _ -> Nothing
     )
     nodes
+
+-- | Extract the nodes of a named connection
+-- | (`blockedBy`, `blocking`, `trackedIssues`,
+-- | `trackedInIssues`) on an Issue content node, turning
+-- | each node into an `Edge` of the given kind and
+-- | source.
+extractEdgeConnection
+  :: String
+  -> EdgeSource
+  -> EdgeKind
+  -> String
+  -> Json
+  -> Array Edge
+extractEdgeConnection selfRepo source kind field contentJson =
+  case toObject contentJson of
+    Nothing -> []
+    Just obj ->
+      case obj .: field of
+        Left _ -> []
+        Right connJson ->
+          case toObject connJson of
+            Nothing -> []
+            Just connObj ->
+              case connObj .: "nodes" of
+                Left _ -> []
+                Right (nodes :: Array Json) ->
+                  mapMaybe (parseEdgeNode selfRepo source kind)
+                    nodes
+
+parseEdgeNode
+  :: String
+  -> EdgeSource
+  -> EdgeKind
+  -> Json
+  -> Maybe Edge
+parseEdgeNode selfRepo source kind nodeJson = do
+  obj <- toObject nodeJson
+  num <- hush (obj .: "number") :: Maybe Int
+  let
+    title_ = hush (obj .: "title") :: Maybe String
+    url_ = hush (obj .: "url") :: Maybe String
+    repo_ = case obj .: "repository" of
+      Right repoJson -> case toObject repoJson of
+        Just repoObj -> case repoObj .: "nameWithOwner" of
+          Right n -> n
+          Left _ -> selfRepo
+        Nothing -> selfRepo
+      Left _ -> selfRepo
+  pure $ Edge
+    { kind
+    , source
+    , repo: repo_
+    , number: num
+    , title: title_
+    , url: url_
+    }
 
 -- | Extract labels from field value nodes.
 extractLabels :: Array Json -> Array String

--- a/src/Lib/Types.purs
+++ b/src/Lib/Types.purs
@@ -16,6 +16,9 @@ module Lib.Types
   , Page(..)
   , AgentSession
   , AgentBranch
+  , Edge(..)
+  , EdgeKind(..)
+  , EdgeSource(..)
   ) where
 
 import Prelude
@@ -283,7 +286,43 @@ newtype ProjectItem = ProjectItem
   , labels :: Array String
   , number :: Maybe Int
   , body :: Maybe String
+  , edges :: Array Edge
   }
+
+-- | Direction / meaning of a dependency edge between
+-- | two issues.
+data EdgeKind
+  = EdgeBlockedBy
+  | EdgeBlocking
+  | EdgeTracks
+  | EdgeTrackedIn
+
+derive instance eqEdgeKind :: Eq EdgeKind
+derive instance ordEdgeKind :: Ord EdgeKind
+
+-- | Which source we learnt the edge from.
+data EdgeSource
+  = SourceNative
+  | SourceTaskList
+  | SourceBody
+
+derive instance eqEdgeSource :: Eq EdgeSource
+derive instance ordEdgeSource :: Ord EdgeSource
+
+-- | A dependency edge pointing from one issue to
+-- | another. `repo` is `"owner/repo"`; when absent
+-- | in source material it defaults to the item's own
+-- | repo.
+newtype Edge = Edge
+  { kind :: EdgeKind
+  , source :: EdgeSource
+  , repo :: String
+  , number :: Int
+  , title :: Maybe String
+  , url :: Maybe String
+  }
+
+derive instance eqEdge :: Eq Edge
 
 -- | Status field metadata for a project.
 type StatusField =

--- a/src/Lib/Util/EdgeParse.purs
+++ b/src/Lib/Util/EdgeParse.purs
@@ -1,0 +1,39 @@
+-- | Extract dependency edges from an issue body by
+-- | scanning for keyword-anchored cross-repo references.
+-- |
+-- | Only references immediately preceded by a dependency
+-- | keyword (`blocked by`, `depends on`, `blocks`, …)
+-- | are kept, to avoid turning every incidental `#42`
+-- | into an edge.
+module Lib.Util.EdgeParse
+  ( parseBodyEdges
+  ) where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Lib.FFI.EdgeRegex (scanEdges, ScanHit)
+import Lib.Types
+  ( Edge(..)
+  , EdgeKind(..)
+  , EdgeSource(..)
+  )
+
+parseBodyEdges :: String -> String -> Array Edge
+parseBodyEdges selfRepo body =
+  map (hitToEdge selfRepo) (scanEdges body)
+
+hitToEdge :: String -> ScanHit -> Edge
+hitToEdge selfRepo hit = Edge
+  { kind: case hit.kind of
+      "blockedBy" -> EdgeBlockedBy
+      "blocking" -> EdgeBlocking
+      _ -> EdgeBlockedBy
+  , source: SourceBody
+  , repo: case hit.repo of
+      "" -> selfRepo
+      r -> r
+  , number: hit.number
+  , title: Nothing
+  , url: Nothing
+  }


### PR DESCRIPTION
## Summary
- Fetch and merge dependency edges from **all three** sources per Kanban item:
  - **Native GitHub issue dependencies** — \`Issue.blockedBy\` / \`Issue.blocking\`
  - **Task-list references** — \`Issue.trackedIssues\` / \`Issue.trackedInIssues\` (the only signal that spans across orgs)
  - **Body keyword scrape** — "blocked by #X", "depends on owner/repo#Y", "blocks …", etc., via a small JS regex FFI
- Expanded items now show grouped "Blocked by / Blocking / Tracks / Tracked in" rows. Each edge links to the referenced issue and carries a \`[native|tasklist|body]\` provenance tag.
- Preview: https://gh-dashboard-edges.surge.sh

## Scope not included
- Graph visualisation (dagre / D3). This PR ships the data + inline listing so we can verify coverage on real projects first. Graph view is a follow-up.

## Test plan
- [ ] Expand an item that has no deps — no new section appears.
- [ ] Expand an item with native \`Blocked by\` links in its sidebar — shows under "Blocked by" with \`[native]\`.
- [ ] Expand an item whose body contains a task-list referencing \`owner/repo#N\` — shows under "Tracks" with \`[tasklist]\`.
- [ ] Expand an item whose body contains \`blocked by owner/repo#N\` — shows under "Blocked by" with \`[body]\`.
- [ ] Cross-org task-list references render correctly (different \`owner/\` prefix).