### PR TITLE
ci: mint dashboard token from the org App

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,13 @@ jobs:
       - uses: paolino/dev-assets/setup-nix@v0.0.1
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - name: Mint a read token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          owner: lambdasistemi
       - run: nix develop --quiet -c just ci
         env:
-          GH_DASHBOARD_TOKEN: ${{ secrets.GH_DASHBOARD_TOKEN }}
+          GH_DASHBOARD_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Replaces `GH_DASHBOARD_TOKEN` PAT with a per-run org-scoped read token from the `lambdasistemi-ci` App. Org-wide PAT→App migration.